### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+## [0.2.0] - 2026-08-18
+
+### 🚀 Features
+
+- Scaffold pytest-rhiza, the rhiza checks as a plugin
+
+### 🐛 Bug Fixes
+
+- Do not invent bash syntax errors where bash does not work
+
+### 🧪 Testing
+
+- Stop assuming every platform has a working bash
+
+### ⚙️ Miscellaneous Tasks
+
+- Point repo at jebel-quant/rhiza@v1.3.3
+- Add project skeleton + license metadata
+- Run the test suite on 3.11-3.14
+- Pin setup-uv to v10.0.1, not the nonexistent v10
+- Test on ubuntu, macos and windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 license-files = ["LICENSE"]
 name = "pytest-rhiza"
-version = "0.1.0"
+version = "0.2.0"
 description = "The rhiza repository checks, as a pytest plugin instead of a synced test folder"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -198,7 +198,7 @@ wheels = [
 
 [[package]]
 name = "pytest-rhiza"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
First release of `pytest-rhiza`. **`0.1.0` → `0.2.0`.**

`v0.2.0` strictly increases past every prior release — there are no tags yet, so this is the repo's first.

### Files the bump touched

| File | Change |
|---|---|
| `pyproject.toml` | `[project].version` `0.1.0` → `0.2.0` (one line) |
| `uv.lock` | the package's own recorded version, same bump |
| `CHANGELOG.md` | **new file** — the `## [0.2.0]` section below |

Exactly one version location is declared, and bump-my-version resolved it natively as `pyproject.toml:project.version`, so the `[project]`-anchoring hazard does not apply. No self-referencing CI stubs exist to bump — every `uses:` in `.github/workflows/` is third-party.

### Changelog section being added

1 feature (the original scaffold), 1 bug fix (the bash probe), 1 test change, 5 miscellaneous. No breaking changes: no `!` subjects and no `BREAKING CHANGE` trailers. Three commits were skipped by git-cliff as unparseable — the two merge commits and `Delete .rhiza directory`, which is not conventional-commit shaped.

### Merging this does not publish the release

There is **no tag yet**, deliberately. A tag must point at a commit that exists on `main`, and a squash-merge would strand one cut now. After this merges, re-run `/rhiza:release` — it detects that the declared version is ahead of the highest tag, and tags the merged commit.

### Why v0.2.0 and not v0.1.1 or v1.0.0

A judgement call, made deliberately: the scaffold is a feature, so `minor` fits the log, and staying pre-1.0 keeps the API explicitly unpromised while the `.rhiza/tests/` migration is still being worked out.
