### PR TITLE
ci: drop conda and devcontainer jobs from rhiza_release

### DIFF
--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -12,7 +12,7 @@
 # must therefore be synced directly into each downstream project so that the publish
 # step runs under the correct repository identity.
 #
-# Release Workflow for Python Packages with Optional Devcontainer Publishing
+# Release Workflow for Python Packages
 #
 # This workflow implements a secure, maintainable release pipeline with distinct phases:
 #
@@ -22,9 +22,7 @@
 #   3. 📦 Generate SBOM - Create Software Bill of Materials (CycloneDX format)
 #   4. 📝 Draft Release - Create draft GitHub release with build artifacts and SBOM
 #   5. 🚀 Publish to PyPI - Publish package using OIDC or custom feed
-#   6. 📦 Generate Conda Recipe - Generate conda-forge recipe with grayskull (conditional)
-#   7. 🐳 Publish Devcontainer - Build and publish devcontainer image (conditional)
-#   8. ✅ Finalize Release - Publish the GitHub release with links
+#   6. ✅ Finalize Release - Publish the GitHub release with links
 #
 # 📄 CHANGELOG: not updated here. The release process (rhiza-claude `/release`)
 # folds a freshly generated CHANGELOG.md into the version-bump commit before the
@@ -38,15 +36,6 @@
 #   - Attached to GitHub releases for transparency and compliance
 #   - Skipped if pyproject.toml doesn't exist
 #
-# 🐳 Devcontainer Publishing:
-#   - Only occurs when PUBLISH_DEVCONTAINER repository variable is set to "true"
-#   - Requires .devcontainer directory to exist
-#   - Uses the release tag (e.g., v1.2.3) as the image tag
-#   - Image name: {registry}/{owner}/{repository}/devcontainer
-#   - Registry defaults to ghcr.io (override with DEVCONTAINER_REGISTRY variable)
-#   - Config file: Always .devcontainer/devcontainer.json
-#   - Adds devcontainer image link to GitHub release notes
-#
 # 🚀 PyPI Publishing:
 #   - Skipped if no dist/ artifacts exist
 #   - Skipped if pyproject.toml contains "Private :: Do Not Upload"
@@ -54,24 +43,15 @@
 #   - For custom feeds, use PYPI_REPOSITORY_URL and PYPI_TOKEN secrets
 #   - Adds PyPI/custom feed link to GitHub release notes
 #
-# 📦 Conda Recipe Generation:
-#   - Runs only when PyPI publishing is enabled and succeeds
-#   - Uses grayskull to generate a conda-forge compatible recipe from PyPI metadata
-#   - Uploads conda-recipe/meta.yaml as a workflow artifact for downstream feedstock updates
-#
 # 🔐 Security:
 #   - No PyPI credentials stored; relies on Trusted Publishing via GitHub OIDC
 #   - For custom feeds, PYPI_TOKEN secret is used with default username __token__
-#   - Container registry uses GITHUB_TOKEN for authentication
 #   - SLSA provenance attestations generated for build artifacts (public repos only)
 #   - SBOM attestations generated for supply chain transparency (public repos only)
 #
 # 📄 Requirements:
 #   - pyproject.toml with top-level version field (for Python packages)
 #   - Package registered on PyPI as Trusted Publisher (for PyPI publishing)
-#   - Conda recipe generation is optional and only runs when PyPI publishing is active
-#   - PUBLISH_DEVCONTAINER variable set to "true" (for devcontainer publishing)
-#   - .devcontainer/devcontainer.json file (for devcontainer publishing)
 #
 # ✅ To Trigger:
 #   Create and push a version tag:
@@ -80,10 +60,6 @@
 #
 # 🎯 For repos without Python packages:
 #   The workflow gracefully skips Python-related steps if pyproject.toml doesn't exist.
-#
-# 🎯 For repos without devcontainers:
-#   The workflow gracefully skips devcontainer steps if PUBLISH_DEVCONTAINER is not
-#   set to "true" or .devcontainer directory doesn't exist.
 
 
 name: (RHIZA) RELEASE
@@ -481,179 +457,11 @@ jobs:
           password: ${{ secrets.PYPI_TOKEN }}
 
 
-  conda:
-    name: Generate Conda Recipe
-    runs-on: ubuntu-latest
-    needs: [tag, pypi]
-    permissions:
-      contents: read   # Generates a recipe and uploads it as a workflow artifact only
-    outputs:
-      should_generate: ${{ steps.check_conda.outputs.should_generate }}
-
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v6.1.0
-        with:
-          fetch-depth: 0
-
-      - name: Check if conda recipe should be generated
-        id: check_conda
-        env:
-          PUBLISH_CONDA: ${{ vars.PUBLISH_CONDA }}
-        run: |
-          PUBLISH_CONDA="${PUBLISH_CONDA:-true}"
-          if [[ "$PUBLISH_CONDA" == "true" ]] && [[ "${{ needs.pypi.outputs.should_publish }}" == "true" ]] && [[ "${{ needs.pypi.result }}" == "success" ]]; then
-            echo "should_generate=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_generate=false" >> "$GITHUB_OUTPUT"
-            echo "⏭️ Skipping conda recipe generation (PUBLISH_CONDA not true, or PyPI publish disabled or failed)"
-          fi
-
-      - name: Set up Python
-        if: steps.check_conda.outputs.should_generate == 'true'
-        uses: actions/setup-python@v6.3.0
-        with:
-          python-version-file: .python-version
-
-      - name: Install grayskull
-        if: steps.check_conda.outputs.should_generate == 'true'
-        run: python -m pip install --upgrade grayskull
-
-      - name: Generate conda recipe with grayskull
-        if: steps.check_conda.outputs.should_generate == 'true'
-        run: |
-          PACKAGE_NAME=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['name'])")
-          mkdir -p /tmp/conda-recipe
-          cd /tmp/conda-recipe
-
-          # PyPI metadata for a just-published release — especially the first
-          # release of a new package — can lag the upload by several minutes,
-          # so retry before giving up.
-          MAX_ATTEMPTS=5
-          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
-            if grayskull pypi "$PACKAGE_NAME" --strict-conda-forge; then
-              break
-            fi
-            if [[ "$attempt" -eq "$MAX_ATTEMPTS" ]]; then
-              echo "::error::grayskull failed after $MAX_ATTEMPTS attempts — PyPI metadata for $PACKAGE_NAME may not be available yet"
-              exit 1
-            fi
-            echo "grayskull attempt $attempt/$MAX_ATTEMPTS failed — waiting 60s for PyPI metadata to propagate"
-            sleep 60
-          done
-
-          RECIPE_PATH=$(find . -type f -path "*/meta.yaml" | head -n 1)
-          if [[ -z "$RECIPE_PATH" ]]; then
-            echo "::error::grayskull did not produce a meta.yaml file"
-            exit 1
-          fi
-
-          mkdir -p "$GITHUB_WORKSPACE/conda-recipe"
-          cp "$RECIPE_PATH" "$GITHUB_WORKSPACE/conda-recipe/meta.yaml"
-
-      - name: Upload conda recipe artifact
-        if: steps.check_conda.outputs.should_generate == 'true'
-        uses: actions/upload-artifact@v7.0.1
-        with:
-          name: conda-recipe
-          path: conda-recipe/meta.yaml
-
-  devcontainer:
-    name: Publish Devcontainer Image
-    runs-on: ubuntu-latest
-    environment: release
-    needs: [tag, build, draft-release]
-    permissions:
-      contents: read
-      packages: write   # Needed to push the devcontainer image to the registry
-    outputs:
-      should_publish: ${{ steps.check_publish.outputs.should_publish }}
-      image_name: ${{ steps.image_name.outputs.image_name }}
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v6.1.0
-        with:
-          fetch-depth: 0
-
-      - name: Check if devcontainer should be published
-        id: check_publish
-        env:
-          PUBLISH_DEVCONTAINER: ${{ vars.PUBLISH_DEVCONTAINER }}
-        run: |
-          if [[ "$PUBLISH_DEVCONTAINER" == "true" ]] && [[ -d ".devcontainer" ]]; then
-            echo "should_publish=true" >> "$GITHUB_OUTPUT"
-            echo "🚀 Will build and publish devcontainer image"
-          else
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            echo "⏭️  Skipping devcontainer publish (PUBLISH_DEVCONTAINER not true or .devcontainer missing)"
-          fi
-
-      - name: Set registry
-        if: steps.check_publish.outputs.should_publish == 'true'
-        id: registry
-        run: |
-          REGISTRY="${{ vars.DEVCONTAINER_REGISTRY }}"
-          if [ -z "$REGISTRY" ]; then
-            REGISTRY="ghcr.io"
-          fi
-          echo "registry=$REGISTRY" >> "$GITHUB_OUTPUT"
-
-      - name: Login to Container Registry
-        if: steps.check_publish.outputs.should_publish == 'true'
-        uses: docker/login-action@v4.6.0
-        with:
-          registry: ${{ steps.registry.outputs.registry }}
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get lowercase repository owner
-        if: steps.check_publish.outputs.should_publish == 'true'
-        id: repo_owner
-        run: echo "owner_lc=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
-
-      - name: Get Image Name
-        if: steps.check_publish.outputs.should_publish == 'true'
-        id: image_name
-        run: |
-          # Check if custom name is provided, otherwise use default
-          if [ -z "${{ vars.DEVCONTAINER_IMAGE_NAME }}" ]; then
-            REPO_NAME_LC=$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')
-            # Sanitize repo name: replace invalid characters with hyphens
-            # Docker image names must match [a-z0-9]+([._-][a-z0-9]+)*
-            # Replace leading dots and multiple consecutive separators
-            REPO_NAME_SANITIZED=$(echo "$REPO_NAME_LC" | sed 's/^[._-]*//; s/[._-][._-]*/-/g')
-            IMAGE_NAME="$REPO_NAME_SANITIZED/devcontainer"
-            echo "Using default image name component: $IMAGE_NAME"
-          else
-            IMAGE_NAME="${{ vars.DEVCONTAINER_IMAGE_NAME }}"
-            echo "Using custom image name component: $IMAGE_NAME"
-          fi
-
-          # Validate the image component matches [a-z0-9]+([._-][a-z0-9]+)* with optional / separators
-          if ! echo "$IMAGE_NAME" | grep -qE '^[a-z0-9]+([._-][a-z0-9]+)*(/[a-z0-9]+([._-][a-z0-9]+)*)*$'; then
-            echo "::error::Invalid image name component: $IMAGE_NAME"
-            echo "::error::Each component must match [a-z0-9]+([._-][a-z0-9]+)* separated by /"
-            exit 1
-          fi
-
-          IMAGE_NAME="${{ steps.registry.outputs.registry }}/${{ steps.repo_owner.outputs.owner_lc }}/$IMAGE_NAME"
-          echo "✅ Final image name: $IMAGE_NAME"
-          echo "image_name=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
-
-      - name: Build and Publish Devcontainer Image
-        if: steps.check_publish.outputs.should_publish == 'true'
-        uses: devcontainers/ci@v0.3.1900000450
-        with:
-          configFile: .devcontainer/devcontainer.json
-          push: always
-          imageName: ${{ steps.image_name.outputs.image_name }}
-          imageTag: ${{ needs.tag.outputs.tag }}
-
   finalise-release:
     name: Finalise Release
     runs-on: ubuntu-latest
-    needs: [tag, pypi, conda, devcontainer]
-    if: needs.pypi.result == 'success' || needs.conda.result == 'success' || needs.devcontainer.result == 'success'
+    needs: [tag, pypi]
+    if: needs.pypi.result == 'success'
     permissions:
       contents: write   # Needed to undraft/publish the GitHub release
     steps:
@@ -676,19 +484,6 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v6.3.0
-
-      - name: Generate Devcontainer Link
-        id: devcontainer_link
-        if: needs.devcontainer.outputs.should_publish == 'true' && needs.devcontainer.result == 'success'
-        run: |
-          FULL_IMAGE="${{ needs.devcontainer.outputs.image_name }}:${{ needs.tag.outputs.tag }}"
-          {
-            echo "message<<EOF"
-            echo "### Devcontainer Image"
-            echo ""
-            echo "\`$FULL_IMAGE\`"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
 
       - name: Generate PyPI Link
         id: pypi_link
@@ -715,25 +510,11 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Generate Conda Recipe Note
-        id: conda_link
-        if: needs.conda.outputs.should_generate == 'true' && needs.conda.result == 'success'
-        run: |
-          {
-            echo "message<<EOF"
-            echo "### Conda Recipe"
-            echo ""
-            echo "A conda-forge recipe was generated with grayskull and uploaded as the \`conda-recipe\` workflow artifact."
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Publish Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.tag.outputs.tag }}
-          DEVCONTAINER_MSG: ${{ steps.devcontainer_link.outputs.message }}
           PYPI_MSG: ${{ steps.pypi_link.outputs.message }}
-          CONDA_MSG: ${{ steps.conda_link.outputs.message }}
         run: |
           # Get existing auto-generated release notes (gracefully handle missing release)
           EXISTING=$(gh release view "$TAG" --json body --jq '.body // ""' 2>/dev/null || echo "")
@@ -741,9 +522,7 @@ jobs:
           # Append links to release body
           {
             printf '%s' "$EXISTING"
-            [ -n "$DEVCONTAINER_MSG" ] && printf '\n\n%s' "$DEVCONTAINER_MSG"
             [ -n "$PYPI_MSG" ] && printf '\n\n%s' "$PYPI_MSG"
-            [ -n "$CONDA_MSG" ] && printf '\n\n%s' "$CONDA_MSG"
           } > /tmp/notes.md
 
           gh release edit "$TAG" --draft=false --notes-file /tmp/notes.md


### PR DESCRIPTION
`pytest-rhiza` publishes a pytest plugin to PyPI and nothing else — there is no `.devcontainer` directory and no conda-forge feedstock. Both jobs were gated on repository variables (`PUBLISH_CONDA`, `PUBLISH_DEVCONTAINER`) that will never be set here, so they were dead weight.

749 → 528 lines.

## Removed

- **`conda`** — the grayskull recipe job: `PUBLISH_CONDA` gate, the PyPI-metadata retry loop, and the `conda-recipe` artifact upload.
- **`devcontainer`** — the `PUBLISH_DEVCONTAINER` gate, registry resolution, `docker/login-action`, image-name derivation and validation, and the `devcontainers/ci` build-and-push. The `packages: write` permission goes with it; nothing else needed it.

Remaining pipeline: `tag → build → draft-release → pypi → finalise-release`.

## `finalise-release` rewired

- `needs: [tag, pypi, conda, devcontainer]` → `needs: [tag, pypi]`
- `if:` reduced to `needs.pypi.result == 'success'`. This is safe because `pypi` has no job-level `if` — it always runs and succeeds even when `should_publish` is false, so a release with nothing to publish still gets undrafted.
- Dropped the *Generate Devcontainer Link* and *Generate Conda Recipe Note* steps plus their `DEVCONTAINER_MSG` / `CONDA_MSG` env vars and `printf` lines. Release notes now carry only the PyPI link.

Header prose trimmed to match: phase list renumbered (8 → 6), the 🐳 and 📦-conda sections deleted, and the now-moot security and requirements bullets removed.

## Note

The header still says the file is rhiza-synced. This repo has no `.rhiza/` pointer, so nothing will overwrite these edits — but if `pytest-rhiza` ever becomes rhiza-managed, a sync would restore both jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)