### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.2.1] - 2026-08-18
+
+### ⚙️ Miscellaneous Tasks
+
+- Add rhiza_release.yml release workflow
+- Drop conda and devcontainer jobs from rhiza_release
 ## [0.2.0] - 2026-08-18
 
 ### 🚀 Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 license-files = ["LICENSE"]
 name = "pytest-rhiza"
-version = "0.2.0"
+version = "0.2.1"
 description = "The rhiza repository checks, as a pytest plugin instead of a synced test folder"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Release **v0.2.0 → v0.2.1** (patch: the unreleased commits are CI-workflow changes, no library behaviour changed).

## Files the bump touched

- `pyproject.toml` — `[project].version` `0.2.0` → `0.2.1`. That is the only declared
  location: `[tool.bumpversion]` carries no `[[files]]` entries and no `current_version`,
  because bump-my-version reads `[project].version` natively (asserted by this package's
  own `checks/test_pyproject.py`).
- `CHANGELOG.md` — one new section prepended, nothing else edited.

No CI stub pins moved: the only first-party `uses:` in `.github/` is
`jebel-quant/actions/configure-git-auth@<sha>`, a different repo pinned by commit SHA.

## Changelog section being added

```markdown
## [0.2.1] - 2026-08-18

### ⚙️ Miscellaneous Tasks

- Add rhiza_release.yml release workflow
- Drop conda and devcontainer jobs from rhiza_release
```

## Merging this does **not** publish the release

No tag exists yet, deliberately. A tag must point at a commit that is on `main`, and a
squash-merge replaces this branch's commit with a new one — so the tag is cut *after*
this merges, by a second `/rhiza:release` run against the merged commit. That run
re-checks that `v0.2.1` strictly increases past every existing tag before creating
anything, then pushes the tag, which is what triggers release CI.
