### PR TITLE
build: add Makefile, pre-commit hooks and a CI lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: prek (pre-commit hooks)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Exact version, not a floating major: astral-sh/setup-uv publishes no `v8`,
+      # `v9` or `v10` alias tag, so `@v10` fails to resolve at job start.
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+
+      # prek is the Rust drop-in for pre-commit and reads .pre-commit-config.yaml
+      # unchanged. `uvx` fetches it, so there is no separate install step — the same
+      # command `make lint` runs locally.
+      #
+      # The ruff hooks rewrite files with `--fix` and `ruff format`; --show-diff-on-failure
+      # prints what they would have changed, so a red run says which edit to make.
+      - name: Run hooks
+        run: uvx prek run --all-files --show-diff-on-failure
+
   test:
     name: pytest (${{ matrix.os }}, ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# Hooks are run by prek (`make lint`), the Rust drop-in for pre-commit. The file
+# format is pre-commit's, so `pre-commit run` works against it unchanged.
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+
+  # ruff.toml is the single source of truth for both rules and formatting.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.3
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+# Minimal entry points for this repo. `uv run` builds and installs pytest-rhiza
+# itself, which is what registers the pytest11 entry point the suite relies on.
+# Hooks run through prek, the Rust drop-in for pre-commit; uvx fetches it, so
+# there is nothing to install up front.
+
+.DEFAULT_GOAL := help
+
+PREK := uvx prek
+
+.PHONY: help lint install-hooks test clean
+
+help: ## Show this help
+	@grep -hE '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) \
+		| awk 'BEGIN {FS = ":.*?## "} {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
+
+lint: ## Run all pre-commit hooks over every file
+	$(PREK) run --all-files
+
+install-hooks: ## Install the git pre-commit hook
+	$(PREK) install
+
+test: ## Run the test suite
+	uv run --group test pytest -ra
+
+clean: ## Remove build artefacts and caches
+	rm -rf dist build .pytest_cache .ruff_cache .coverage htmlcov *.egg-info src/*.egg-info
+	find . -path ./.venv -prune -o -name '__pycache__' -type d -exec rm -rf {} +
+
+-include local.mk

--- a/uv.lock
+++ b/uv.lock
@@ -198,7 +198,7 @@ wheels = [
 
 [[package]]
 name = "pytest-rhiza"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
## What

- **`Makefile`** — `help` (the default goal, listing every target), `test`, `clean`, `lint`, `install-hooks`. `make test` mirrors what CI runs. `-include local.mk` picks up the already-gitignored file for personal targets, and any target tagged with a `## description` comment shows up in `make help` automatically.
- **`.pre-commit-config.yaml`** — `pre-commit-hooks` v6.0.0 (whitespace, EOF, yaml/toml, merge conflicts, large files) and `ruff-pre-commit` v0.16.3 (`ruff-check --fix`, `ruff-format`). The ruff hooks read the existing `ruff.toml` rather than restating any of it.
- **CI `lint` job** — runs the same command as `make lint`, with `--show-diff-on-failure` so a red run prints the edit the auto-fixing ruff hooks wanted to make. Independent of the pytest matrix; ubuntu only, since the hooks are platform-independent.

Hooks run through [prek](https://github.com/j178/prek), the Rust drop-in for pre-commit, fetched via `uvx` — nothing to install first, locally or in CI. The config file stays in pre-commit's own format, so `pre-commit run` works against it unchanged.

## Also

Refreshes `uv.lock`, which still carried `0.2.0` after the 0.2.1 release. It updated on its own when `make test` rebuilt the package.

## Verified locally

- `make lint` — all 8 hooks pass on the current tree
- `make test` — 18 passed
- `make clean`, `make help` — as expected

The CI lint job itself is untested until this run goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)