### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.2.2] - 2026-08-18
+
+### 💼 Other
+
+- Add Makefile, pre-commit hooks and a CI lint job
 ## [0.2.1] - 2026-08-18
 
 ### ⚙️ Miscellaneous Tasks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 license = "MIT"
 license-files = ["LICENSE"]
 name = "pytest-rhiza"
-version = "0.2.1"
+version = "0.2.2"
 description = "The rhiza repository checks, as a pytest plugin instead of a synced test folder"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -198,7 +198,7 @@ wheels = [
 
 [[package]]
 name = "pytest-rhiza"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
Prepares the v0.2.2 release so the tagged commit already carries the changelog, as `rhiza_release.yml` requires.

- `pyproject.toml`: `0.2.1` → `0.2.2` via `bump-my-version bump patch`
- `CHANGELOG.md`: entry prepended with `git-cliff --unreleased --tag v0.2.2`

Covers one commit since `v0.2.1`: `19ed1dd build: add Makefile, pre-commit hooks and a CI lint job`.

Gates run locally, both green:
- `make test` — 18 passed, pytest reports `rhiza-0.2.2`
- `make lint` — all prek hooks passed

After merge, tag the merge commit `v0.2.2` and push the tag to trigger the release workflow (build → SBOM → draft release → PyPI via OIDC → finalize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)