### PR TITLE
ci: adopt the rhiza v1.4.2 workflow stubs and make their gates green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,25 @@ jobs:
       # it, so the Windows runner's git works the same as the others.
       - name: Run tests
         run: uv run --group test --python ${{ matrix.python-version }} pytest -ra
+
+  audit:
+    name: pip-audit (dependency CVEs)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Exact version, not a floating major: astral-sh/setup-uv publishes no `v8`,
+      # `v9` or `v10` alias tag, so `@v10` fails to resolve at job start.
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+
+      # The `security` gate rhiza_ci.yml runs is bandit only — it scans *our* source for
+      # insecure patterns and never looks at what we depend on. This is the other half:
+      # pip-audit resolves the locked environment and checks it against the advisory
+      # database. It matters more here than in most projects, because pytest-rhiza is a
+      # runtime dependency of every rhiza-managed repo, so a vulnerable transitive
+      # dependency propagates into every consumer's test environment.
+      - name: Audit dependencies
+        run: uvx pip-audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,16 @@ jobs:
       # The suite shells out to git (the `latest_tag` fixture, and the throwaway repos
       # the tests build), and it is `git` on PATH that is used — `shutil.which` resolves
       # it, so the Windows runner's git works the same as the others.
+      #
+      # The coverage flags mirror `make test` and `rhiza-task test`, so the threshold is
+      # the same number in all three places. Measuring it at all depends on
+      # `[tool.coverage.run] patch = ["subprocess"]` in pyproject.toml: the checks are
+      # exercised by inner `pytest --pyargs` runs in subprocesses, which a parent-only
+      # coverage run does not see.
       - name: Run tests
-        run: uv run --group test --python ${{ matrix.python-version }} pytest -ra
+        run: >-
+          uv run --group test --python ${{ matrix.python-version }}
+          pytest -ra --cov=src --cov-report=term-missing --cov-fail-under=90
 
   audit:
     name: pip-audit (dependency CVEs)

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -1,0 +1,30 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: Continuous Integration
+#
+# Purpose: Run tests on multiple Python versions, check dependencies, run
+#          pre-commit hooks, verify documentation coverage, validate the
+#          project, run security scans, and check license compliance.
+#
+# Python version matrix source of truth:
+# - Implemented in the reusable workflow called below
+# - Generated from `Programming Language :: Python :: 3.x` classifiers in pyproject.toml
+# - Adding/removing classifiers updates CI Python coverage automatically
+#
+# Trigger: On push and pull_request.
+
+name: "(RHIZA) CI"
+
+permissions:
+  contents: read
+  actions: read
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ci:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.4.2
+    secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -1,0 +1,35 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: CodeQL
+#
+# Purpose: Automated code scanning for Python and GitHub Actions using
+#          GitHub's CodeQL engine. Free for public repositories; requires
+#          GitHub Advanced Security for private repositories.
+#          Set the CODEQL_ENABLED repository variable to 'true' to force-enable
+#          on private repos, 'false' to disable, or leave unset for auto-detect.
+#
+# Trigger: On push to main/master, pull requests, and weekly schedule.
+
+name: "(RHIZA) CODEQL"
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+    branches: [ "main", "master" ]
+  schedule:
+    - cron: '27 1 * * 1'
+
+jobs:
+  codeql:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.4.2
+    secrets: inherit
+    permissions:
+      security-events: write   # Upload CodeQL results to code scanning
+      packages: read
+      actions: read
+      contents: read

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -1,0 +1,45 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: OSSF Scorecard
+#
+# Purpose: Run the OpenSSF Scorecard supply-chain security analysis and upload
+#          the results to GitHub code scanning. On public repositories the
+#          results are also published to the OpenSSF REST API, which powers
+#          the README badge and lets adopters verify the score independently.
+#          Set the SCORECARD_ENABLED repository variable to 'true' to
+#          force-enable on private repos, 'false' to disable, or leave unset
+#          for auto-detect (public repositories only).
+#
+#          Thin stub: the analysis logic and its enablement/visibility gate
+#          live in the reusable workflow in jebel-quant/rhiza; this file only
+#          wires up the triggers and grants the token scopes Scorecard needs.
+#
+# Trigger: Weekly schedule, pushes to main, branch-protection changes, and
+#          manual dispatch.
+
+name: "(RHIZA) SCORECARD"
+
+on:
+  # Re-evaluate when branch protection rules change (Scorecard's
+  # Branch-Protection check reads them).
+  branch_protection_rule:
+  schedule:
+    - cron: '34 2 * * 2'
+  push:
+    branches: [ "main", "master" ]
+  workflow_dispatch:
+
+# Least privilege by default; the called workflow grants its job only what
+# Scorecard needs (see the job-level permissions below).
+permissions: read-all
+
+jobs:
+  scorecard:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.4.2
+    secrets: inherit
+    permissions:
+      security-events: write   # Upload the SARIF results to code scanning
+      id-token: write          # Publish results to the OpenSSF REST API (badge)
+      contents: read
+      actions: read

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -1,0 +1,32 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: Weekly
+#
+# Purpose: Runs checks that are too slow or noisy for every push:
+#   dep-compat-test — resolves dependencies fresh (ignoring the lockfile) and
+#                     runs the full test suite to catch newly-released packages
+#                     that break compatibility before Renovate picks them up.
+#   link-check      — verifies all hyperlinks in README.md are reachable.
+#
+# Trigger: Weekly schedule (Monday 08:00 UTC) and manual dispatch.
+
+name: "(RHIZA) WEEKLY"
+
+permissions:
+  contents: read
+
+on:
+  #push:
+  #  branches: [main]
+  #  paths: [README.md]
+  #pull_request:
+  #  paths: [README.md]
+  schedule:
+    - cron: "0 8 * * 1"  # Every Monday at 08:00 UTC
+  workflow_dispatch:
+
+jobs:
+  weekly:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.4.2
+    secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,13 @@ lint: ## Run all pre-commit hooks over every file
 install-hooks: ## Install the git pre-commit hook
 	$(PREK) install
 
-test: ## Run the test suite
-	uv run --group test pytest -ra
+# Same flags CI runs, deliberately: a coverage threshold that only exists in one of the
+# two is a threshold nobody notices crossing. `--cov=src` matches what `rhiza-task test`
+# passes, and the 90 is its default `coverage_fail_under`. Subprocess measurement is
+# configured in pyproject.toml — without it this number is meaningless, because the
+# checks only ever execute in child processes.
+test: ## Run the test suite with coverage
+	uv run --group test pytest -ra --cov=src --cov-report=term-missing --cov-fail-under=90
 
 clean: ## Remove build artefacts and caches
 	rm -rf dist build .pytest_cache .ruff_cache .coverage htmlcov *.egg-info src/*.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,23 @@ classifiers = [
 # --with python-dotenv --with packaging`), which is the argument for a dedicated
 # distribution: folding the checks into `rhiza` would drag jinja2, typer and rich into
 # every test environment, and into `rhiza-tools` would add pandas and plotly.
+#
+# The pytest floor is 8.1, not 8.0, and the reason is specific to how this package is
+# consumed. `--pyargs` is the whole interface: the checks live in site-packages and are
+# named on the command line, so the repository under test and the installed modules sit
+# in two unrelated directory trees. Up to and including 8.0.2, pytest walked the *generic*
+# ancestor chain of a `--pyargs` argument and fully scanned the first directory outside
+# confcutdir — on a GitHub ubuntu runner that is `/home`, whose `packer` entry the
+# `runner` user cannot stat, so collection died with a PermissionError and zero tests
+# (#23). 8.1.0 added a `--pyargs` branch that stops at the package hierarchy:
+#
+#     # For --pyargs arguments, only consider paths matching the module
+#     # name. Paths beyond the package hierarchy are not included.
+#
+# Bisected: 8.0.0, 8.0.1 and 8.0.2 fail, 8.1.0 onwards pass. In practice `>=8.1`
+# resolves to 8.1.1, 8.1.0 having been yanked from PyPI.
 dependencies = [
-    "pytest>=8.0",
+    "pytest>=8.1",
     "pytest-timeout>=2.3",
     "python-dotenv>=1.0",
     "packaging>=24.0",
@@ -40,7 +55,7 @@ Issues = "https://github.com/jebel-quant/pytest-rhiza/issues"
 rhiza = "pytest_rhiza.plugin"
 
 [dependency-groups]
-test = ["pytest>=8.0", "pytest-cov>=6.0"]
+test = ["pytest>=8.1", "pytest-cov>=6.0"]
 
 [build-system]
 requires = ["hatchling"]
@@ -69,3 +84,12 @@ DEP002 = ["pytest-timeout"]
 allow_dirty = false
 commit = false
 tag = false
+
+# Without this the coverage number for this package is meaningless. The checks are
+# *tests*: they are exercised by naming them on an inner `pytest --pyargs` command line
+# in a subprocess, never by importing them, so a coverage run that only watches the
+# parent process sees `src/pytest_rhiza/checks/` at 0% however thoroughly it is tested.
+# `patch = ["subprocess"]` makes coverage inject its own start-up into every child the
+# suite spawns, which is where the checks actually execute.
+[tool.coverage.run]
+patch = ["subprocess"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,20 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/pytest_rhiza"]
 
+# deptry compares *declared* dependencies against *imported* ones, which mis-reads two of
+# the four runtime deps. Both entries below are mappings, not suppressions of a real gap.
+[tool.deptry.package_module_name_map]
+# The distribution is `python-dotenv`; the module it installs is `dotenv`. Without this
+# deptry infers `python_dotenv`, then reports the declared package as unused *and* the
+# import as undeclared — the same finding twice, from one wrong guess.
+python-dotenv = ["dotenv"]
+
+[tool.deptry.per_rule_ignores]
+# pytest-timeout is consumed through its own pytest11 entry point and is never imported,
+# so deptry cannot see the use. It is declared for the same reason the block above lists
+# it: a consumer installing this package must get the plugin the checks run under.
+DEP002 = ["pytest-timeout"]
+
 # bump-my-version reads [project].version natively; /rhiza:release owns the commit and
 # the tag. Asserted by this package's own checks/test_pyproject.py, run against itself.
 [tool.bumpversion]

--- a/src/pytest_rhiza/checks/test_docstrings.py
+++ b/src/pytest_rhiza/checks/test_docstrings.py
@@ -170,9 +170,17 @@ def test_doctests(logger, root, monkeypatch: pytest.MonkeyPatch, capsys: pytest.
             logger.debug("Doctests passed for %s (%d test(s))", module.__name__, results.attempted)
 
     for src_path in folders:
+        # A configured folder may *be* a package rather than contain them: a flat-layout
+        # project names its package directly, so `SOURCE_FOLDER=mypackage`. Its modules
+        # are then importable relative to the folder's parent, and resolving them against
+        # the folder itself derives an empty module name for `__init__.py` — which is a
+        # ValueError from importlib rather than the ImportError the walk expects, so the
+        # whole gate crashed instead of reporting anything.
+        import_root = src_path.parent if (src_path / "__init__.py").exists() else src_path
+
         # Add the folder to sys.path with automatic cleanup
-        monkeypatch.syspath_prepend(str(src_path))
-        logger.debug("Prepended to sys.path: %s", src_path)
+        monkeypatch.syspath_prepend(str(import_root))
+        logger.debug("Prepended to sys.path: %s", import_root)
 
         # Find all packages in the folder (supports namespace packages)
         for package_dir in _find_packages(src_path):
@@ -181,7 +189,7 @@ def test_doctests(logger, root, monkeypatch: pytest.MonkeyPatch, capsys: pytest.
                 package_name = package_dir.name
                 logger.info("Discovered package: %s", package_name)
                 try:
-                    modules = list(_iter_modules_from_path(logger, package_dir, src_path))
+                    modules = list(_iter_modules_from_path(logger, package_dir, import_root))
                     logger.debug("%d module(s) found in package %s", len(modules), package_name)
 
                     for module in modules:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,190 @@
 ``pytester`` is what lets a plugin's tests run pytest inside pytest: each test gets a
 throwaway directory, and assertions are made about the inner run's outcomes. That is the
 only honest way to test fixtures whose whole job is to answer "which repository is this".
+
+The other harness here is :func:`subject`, and it exists because the *checks* cannot be
+tested that way. A check module is collected out of site-packages by name — ``pytest
+--pyargs pytest_rhiza.checks.test_pyproject`` — and judges a repository it is pointed at
+with ``--rhiza-root``. So exercising one means building a repository for it to judge and
+running the real command line against it, in a subprocess, exactly as a consumer does.
+``pytester`` cannot stand in for that: it drives an *in-process* run over files it writes
+itself, which is a different code path from the one every rhiza-managed repo uses.
+
+Two consequences worth knowing before adding tests here:
+
+* Coverage of ``src/pytest_rhiza/checks/`` comes entirely from these subprocesses, which
+  is why ``[tool.coverage.run] patch = ["subprocess"]`` is set in pyproject.toml.
+* A subject usually needs to be a git repository with a tag, because the version checks
+  compare a manifest against ``git describe``-style state. :meth:`Subject.commit` and the
+  ``tag`` argument to the factory cover that.
 """
 
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # nosec B404
+import sys
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
 pytest_plugins = ["pytester"]
+
+_GIT = shutil.which("git") or "/usr/bin/git"
+
+
+class Subject:
+    """A throwaway repository the installed checks are run against.
+
+    Attributes:
+        path: The repository root, which is what ``--rhiza-root`` is pointed at.
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Store the repository root.
+
+        Args:
+            path: Directory that plays the part of a consumer repository.
+        """
+        self.path = path
+
+    def write(self, files: Mapping[str, str]) -> None:
+        """Write files into the subject, creating parent directories as needed.
+
+        Args:
+            files: Repository-relative path to file content. Content is passed through
+                :func:`textwrap.dedent` and stripped of one leading newline, so callers
+                can use indented triple-quoted strings.
+        """
+        for name, text in files.items():
+            target = self.path / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            # newline="\n" rather than the platform default: a subject is *input to a
+            # parser*, and the fence regexes in `_fences` are written against "\n". A
+            # Windows runner silently rewriting them to "\r\n" would make these tests
+            # measure the line-ending translation rather than the check.
+            target.write_text(dedent(text).lstrip("\n"), encoding="utf-8", newline="\n")
+
+    def git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        """Run one git command inside the subject.
+
+        Args:
+            args: Arguments after the ``git`` executable.
+
+        Returns:
+            The completed process; output is captured and stdout/stderr are text.
+        """
+        return subprocess.run(  # nosec B603
+            [_GIT, *args], cwd=self.path, check=True, capture_output=True, text=True
+        )
+
+    def commit(self, message: str = "seed", *, tag: str | None = None) -> None:
+        """Commit everything currently written, optionally tagging the result.
+
+        Args:
+            message: Commit message.
+            tag: Tag to place on the new commit, e.g. ``v1.2.3``.
+        """
+        self.git("add", "-A")
+        # --allow-empty: a subject may deliberately hold no files at all (the checks
+        # then report the manifest as missing), and it still needs a commit to tag.
+        self.git("commit", "-q", "--allow-empty", "-m", message)
+        if tag is not None:
+            self.git("tag", tag)
+
+    def run(
+        self,
+        *modules: str,
+        args: tuple[str, ...] = (),
+        env: Mapping[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run the named installed check modules against this subject.
+
+        The command line is the one a consumer repository uses, and it is run in a
+        subprocess for the same reason: ``--pyargs`` resolves the modules out of
+        site-packages, and the plugin's ``root`` fixture has to resolve the repository
+        from ``--rhiza-root`` rather than from anything the outer session knows.
+
+        Args:
+            modules: Dotted module names, without the ``pytest_rhiza.checks.`` prefix.
+            args: Extra arguments appended to the command line.
+            env: Environment entries to add for this run. ``make rhiza-test`` configures
+                the docstring check through ``RHIZA_DOCTEST_FOLDERS``, so that path is
+                only reachable by setting it here.
+
+        Returns:
+            The completed process, with stdout and stderr captured as text.
+        """
+        return subprocess.run(  # nosec B603
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-p",
+                "no:cacheprovider",
+                "-q",
+                "--tb=line",
+                # Skip reasons are the check's verdict in the cases where skipping *is*
+                # the right answer, so the tests have to be able to read them back.
+                "-rs",
+                "--pyargs",
+                *(f"pytest_rhiza.checks.{name}" for name in modules),
+                "--rhiza-root",
+                str(self.path),
+                *args,
+            ],
+            cwd=self.path,
+            capture_output=True,
+            text=True,
+            env={**os.environ, **env} if env else None,
+        )
+
+
+@pytest.fixture
+def subject(tmp_path_factory: pytest.TempPathFactory) -> Callable[..., Subject]:
+    """Return a factory building throwaway repositories for the checks to judge.
+
+    A fresh directory per call, so one test can compare a sound subject against a broken
+    one. ``git=True`` is the default because most checks reach for a tag: the version
+    tests compare a manifest against the newest ``vX.Y.Z``, and with no repository at all
+    they skip rather than judge, which is the failure mode most likely to make a test
+    look like it passed when it never ran.
+
+    Args:
+        tmp_path_factory: pytest's per-session temporary directory factory.
+
+    Returns:
+        ``make(files, *, tag=None, git=True) -> Subject``.
+    """
+    counter = 0
+
+    def make(files: Mapping[str, str] | None = None, *, tag: str | None = None, git: bool = True) -> Subject:
+        """Build one subject repository.
+
+        Args:
+            files: Repository-relative path to file content, written before the commit.
+            tag: Tag to place on the seed commit, e.g. ``v1.2.3``.
+            git: Whether to initialise a repository and commit. ``False`` leaves an empty
+                directory, which is what a ``git clone`` target needs.
+
+        Returns:
+            The built subject.
+        """
+        nonlocal counter
+        counter += 1
+        root = tmp_path_factory.mktemp(f"subject{counter}")
+        built = Subject(root)
+        if files:
+            built.write(files)
+        if git:
+            built.git("init", "-q")
+            built.git("config", "user.email", "test@example.com")
+            built.git("config", "user.name", "test")
+            built.git("config", "commit.gpgsign", "false")
+            built.commit(tag=tag)
+        return built
+
+    return make

--- a/tests/test_check_cargo_toml.py
+++ b/tests/test_check_cargo_toml.py
@@ -1,0 +1,302 @@
+"""Subject-repository tests for ``checks/test_cargo_toml.py``.
+
+This module and ``test_check_go_module.py`` are the ones issue #10 called out as
+mattering most: the Rust and Go checks can only ever fire inside a Rust or Go consumer
+repository, so before these tests a regression in them shipped silently and surfaced on
+somebody else's CI. Nothing in this repository is a crate, which is exactly why the
+subject has to be built rather than found.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import only for the fixture's type
+    from conftest import Subject
+
+SOUND_CARGO = """
+[package]
+name = "demo"
+version = "1.2.3"
+edition = "2021"
+description = "A demonstration crate"
+license = "MIT"
+
+[dependencies]
+serde = "1.2.3"
+"""
+
+# Anchored to the [package] table, which is the property
+# ``test_the_cargo_toml_pattern_is_anchored_to_the_package_table`` exists to defend: the
+# [dependencies] entry above shares the crate's version number on purpose.
+SOUND_BUMPVERSION = """
+[tool.bumpversion]
+allow_dirty = false
+commit = false
+tag = false
+tag_name = "v{new_version}"
+
+[[tool.bumpversion.files]]
+filename = "Cargo.toml"
+regex = true
+search = '\\[package\\]([\\s\\S]*?)version = "{current_version}"'
+replace = '[package]\\1version = "{new_version}"'
+"""
+
+TOTAL_CHECKS = 17
+
+
+def _crate(**extra: str) -> dict[str, str]:
+    """Return the file map for a sound crate, with any extra files merged in.
+
+    Args:
+        extra: Additional repository-relative files, overriding the sound ones by name.
+
+    Returns:
+        The file map to hand to the ``subject`` factory.
+    """
+    return {"Cargo.toml": SOUND_CARGO, ".bumpversion.toml": SOUND_BUMPVERSION, **extra}
+
+
+class TestSoundSubject:
+    """A crate carrying everything the check asks for passes all of it."""
+
+    def test_a_complete_crate_passes_every_check(self, subject: Callable[..., Subject]) -> None:
+        """The reference case, and the only test here that proves the check can pass."""
+        repo = subject(_crate(), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert f"{TOTAL_CHECKS} passed" in result.stdout, result.stdout
+
+
+class TestManifestShape:
+    """Cargo.toml's presence, parseability, and the fields cargo publish requires."""
+
+    def test_a_repository_without_a_manifest_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """No Cargo.toml: the existence assertion fires and the rest skip."""
+        repo = subject({".bumpversion.toml": SOUND_BUMPVERSION}, tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "Cargo.toml not found at project root" in result.stdout, result.stdout
+
+    def test_a_virtual_workspace_manifest_skips_the_package_checks(self, subject: Callable[..., Subject]) -> None:
+        """A workspace root legitimately has no ``[package]`` — its members hold versions."""
+        repo = subject(_crate(**{"Cargo.toml": '[workspace]\nmembers = ["crates/*"]\n'}), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert "virtual workspace manifest" in result.stdout, result.stdout
+
+    def test_a_manifest_that_is_neither_package_nor_workspace_fails(self, subject: Callable[..., Subject]) -> None:
+        """Without either table there is nothing legitimate to skip for."""
+        repo = subject(_crate(**{"Cargo.toml": '[dependencies]\nserde = "1"\n'}), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "Cargo.toml is missing a [package] table" in result.stdout, result.stdout
+
+    def test_missing_package_fields_are_each_reported(self, subject: Callable[..., Subject]) -> None:
+        """One failure per absent field: name, version, edition, description."""
+        repo = subject(_crate(**{"Cargo.toml": '[package]\nlicense = "MIT"\n'}), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        for field in ("name", "version", "edition", "description"):
+            assert f"missing required field '{field}'" in result.stdout, result.stdout
+
+    def test_a_blank_name_or_description_is_rejected(self, subject: Callable[..., Subject]) -> None:
+        """Present-but-whitespace is the same defect as absent, and looks configured."""
+        manifest = SOUND_CARGO.replace('name = "demo"', 'name = " "').replace(
+            'description = "A demonstration crate"', 'description = "  "'
+        )
+        repo = subject(_crate(**{"Cargo.toml": manifest}), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "[package].name must be a non-empty string" in result.stdout, result.stdout
+        assert "[package].description must be a non-empty string" in result.stdout, result.stdout
+
+    def test_a_non_semver_version_is_rejected(self, subject: Callable[..., Subject]) -> None:
+        """``.bumpversion.toml``'s parse regex assumes MAJOR.MINOR.PATCH, so cargo's laxity is not enough."""
+        manifest = SOUND_CARGO.replace('version = "1.2.3"', 'version = "1.2"')
+        repo = subject(_crate(**{"Cargo.toml": manifest}))
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "does not follow semver" in result.stdout, result.stdout
+
+    def test_workspace_inherited_fields_skip_rather_than_fail(self, subject: Callable[..., Subject]) -> None:
+        """``version.workspace = true`` parses as a table, and the member has nothing to assert."""
+        manifest = SOUND_CARGO.replace('version = "1.2.3"', "version.workspace = true").replace(
+            'description = "A demonstration crate"', "description.workspace = true"
+        )
+        repo = subject(_crate(**{"Cargo.toml": manifest}), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "inherited from the workspace" in result.stdout, result.stdout
+
+    def test_a_crate_stating_no_licence_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """``cargo deny check licenses`` is an allow-list and fails the crate on itself."""
+        manifest = SOUND_CARGO.replace('license = "MIT"\n', "")
+        repo = subject(_crate(**{"Cargo.toml": manifest}), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "declares neither 'license' nor 'license-file'" in result.stdout, result.stdout
+
+    def test_a_licence_file_satisfies_the_licence_assertion(self, subject: Callable[..., Subject]) -> None:
+        """``license-file`` is the other accepted form, for a licence cargo cannot name."""
+        manifest = SOUND_CARGO.replace('license = "MIT"', 'license-file = "LICENSE"')
+        repo = subject(_crate(**{"Cargo.toml": manifest, "LICENSE": "Custom terms\n"}), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestBumpversionConfig:
+    """The shipped ``.bumpversion.toml`` must stay the config that wins, and stay pointed at Cargo.toml."""
+
+    def test_no_config_anywhere_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """A Rust project owns none of the four discoverable filenames, so rust-core ships one."""
+        repo = subject({"Cargo.toml": SOUND_CARGO}, tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "No bumpversion config was found" in result.stdout, result.stdout
+        assert ".bumpversion.toml not found" in result.stdout, result.stdout
+
+    def test_a_leftover_cfg_toml_earns_the_extra_hint(self, subject: Callable[..., Subject]) -> None:
+        """``.rhiza/.cfg.toml`` is never auto-discovered; the failure should say so."""
+        repo = subject(
+            {"Cargo.toml": SOUND_CARGO, ".rhiza/.cfg.toml": '[tool.bumpversion]\ncurrent_version = "1.2.3"\n'},
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "A leftover .rhiza/.cfg.toml is present" in result.stdout, result.stdout
+
+    def test_an_unparseable_config_counts_as_absent(self, subject: Callable[..., Subject]) -> None:
+        """Malformed TOML cannot be the config that runs, so it is reported as missing."""
+        repo = subject({"Cargo.toml": SOUND_CARGO, ".bumpversion.toml": "not = = toml\n"}, tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "No bumpversion config was found" in result.stdout, result.stdout
+
+    def test_a_second_config_in_pyproject_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """The reverse mistake: a Rust repo carrying a Python manifest declares the table twice."""
+        repo = subject(
+            _crate(**{"pyproject.toml": '[project]\nname = "helper"\n\n[tool.bumpversion]\ncommit = false\n'}),
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "also declares a bumpversion section" in result.stdout, result.stdout
+
+    def test_an_ini_config_is_detected_by_text(self, subject: Callable[..., Subject]) -> None:
+        """``setup.cfg`` is INI, so presence is a substring test rather than a TOML lookup."""
+        repo = subject(_crate(**{"setup.cfg": "[bumpversion]\ncurrent_version = 1.2.3\n"}), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "'setup.cfg'" in result.stdout, result.stdout
+
+    def test_a_pinned_current_version_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """The file is synced, so a value only the consumer maintains gets overwritten."""
+        config = SOUND_BUMPVERSION.replace("[tool.bumpversion]", '[tool.bumpversion]\ncurrent_version = "1.2.3"')
+        repo = subject(_crate(**{".bumpversion.toml": config}), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "current_version is set in a file rhiza syncs" in result.stdout, result.stdout
+
+    def test_a_config_targeting_nothing_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """With no ``[[files]]`` entry the bump succeeds while rewriting nothing."""
+        config = "[tool.bumpversion]\ncommit = false\ntag = false\n"
+        repo = subject(_crate(**{".bumpversion.toml": config}), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "no [[tool.bumpversion.files]] entry targets Cargo.toml" in result.stdout, result.stdout
+        assert "no Cargo.toml entry" in result.stdout, result.stdout
+
+    def test_a_non_regex_search_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """A plain search cannot be anchored, so it also rewrites a same-numbered dependency."""
+        config = SOUND_BUMPVERSION.replace("regex = true\n", "").replace(
+            "search = '\\[package\\]([\\s\\S]*?)version = \"{current_version}\"'",
+            "search = 'version = \"{current_version}\"'",
+        )
+        repo = subject(_crate(**{".bumpversion.toml": config}), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "is not a regex" in result.stdout, result.stdout
+
+    def test_a_regex_search_that_is_not_anchored_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """Regex alone is not enough — it has to mention the ``[package]`` table."""
+        config = SOUND_BUMPVERSION.replace(
+            "search = '\\[package\\]([\\s\\S]*?)version = \"{current_version}\"'",
+            "search = 'version = \"{current_version}\"'",
+        )
+        repo = subject(_crate(**{".bumpversion.toml": config}), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "does not mention the [package] table" in result.stdout, result.stdout
+
+    def test_committing_and_tagging_from_the_bump_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """``/rhiza:release`` owns both; a config doing them adds a duplicate tag."""
+        config = SOUND_BUMPVERSION.replace("commit = false\ntag = false", "commit = true\ntag = true")
+        repo = subject(_crate(**{".bumpversion.toml": config}), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "must be false: the release flow commits and tags" in result.stdout, result.stdout
+
+
+class TestTagAgreement:
+    """The crate version and the newest tag are one fact recorded twice."""
+
+    def test_a_version_disagreeing_with_the_tag_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """bump-my-version reads the version from the tag and then looks for it in Cargo.toml."""
+        manifest = SOUND_CARGO.replace('version = "1.2.3"', 'version = "9.9.9"')
+        repo = subject(_crate(**{"Cargo.toml": manifest}), tag="v1.2.3")
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode != 0
+        assert "bump-my-version derives the current version from the tag" in result.stdout, result.stdout
+
+    def test_an_untagged_repository_skips_the_comparison(self, subject: Callable[..., Subject]) -> None:
+        """A crate that has never released must not fail the version checks."""
+        repo = subject(_crate())
+
+        result = repo.run("test_cargo_toml")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "No version tags found" in result.stdout, result.stdout

--- a/tests/test_check_docstrings.py
+++ b/tests/test_check_docstrings.py
@@ -1,0 +1,224 @@
+"""Subject-repository tests for ``checks/test_docstrings.py``.
+
+The check discovers Python under configured folders, imports each module and runs its
+doctests. Three properties are worth pinning, and none of them could be observed before
+this file existed:
+
+* **Where it looks.** ``RHIZA_DOCTEST_FOLDERS``, then ``SOURCE_FOLDER`` from
+  ``.rhiza/.env``, then ``src``. #1517 is the bug that ordering exists to fix — a project
+  keeping Python outside its source root had its examples silently skipped.
+* **What it reaches.** Packages, namespace-nested packages, and loose scripts in a folder
+  with no ``__init__.py`` are three different discovery paths.
+* **How it fails.** A wrong example fails; a module that cannot be *imported* warns and
+  is skipped, because "we could not measure this" is a different statement.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import only for the fixture's type
+    from conftest import Subject
+
+PASSING_PACKAGE = '''
+"""A demonstration package.
+
+Examples:
+    >>> 1 + 1
+    2
+"""
+'''
+
+PASSING_MODULE = '''
+"""A demonstration module.
+
+Examples:
+    >>> "rhiza".upper()
+    'RHIZA'
+"""
+'''
+
+FAILING_MODULE = '''
+"""A module whose example is wrong.
+
+Examples:
+    >>> 2 + 2
+    5
+"""
+'''
+
+
+class TestDiscoveryScope:
+    """Which folders the check looks in, and what it does when it finds nothing."""
+
+    def test_it_defaults_to_src_and_runs_the_examples_it_finds(self, subject: Callable[..., Subject]) -> None:
+        """With nothing configured the folder is ``src``, covering both file shapes.
+
+        ``__init__.py`` and a sibling module are separate branches of the module-name
+        derivation — one names the package, the other the file — so both are present.
+        """
+        repo = subject(
+            {"src/demopkg/__init__.py": PASSING_PACKAGE, "src/demopkg/greet.py": PASSING_MODULE},
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_docstrings")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "1 passed" in result.stdout, result.stdout
+
+    def test_a_repository_with_no_source_folder_skips(self, subject: Callable[..., Subject]) -> None:
+        """Nothing to measure is a skip that names what it looked for, not a pass."""
+        repo = subject({"README.md": "# Demo\n"}, tag="v1.2.3")
+
+        result = repo.run("test_docstrings")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "No doctest folder found (looked for: src)" in result.stdout, result.stdout
+
+    def test_source_folder_from_the_rhiza_env_file_is_honoured(self, subject: Callable[..., Subject]) -> None:
+        """A project whose Python lives outside ``src`` declares it in ``.rhiza/.env``."""
+        repo = subject(
+            {".rhiza/.env": "SOURCE_FOLDER=lib\n", "lib/demopkg/__init__.py": PASSING_PACKAGE},
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_docstrings")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "1 passed" in result.stdout, result.stdout
+
+    def test_an_env_file_pointing_at_nothing_skips_naming_the_folder(self, subject: Callable[..., Subject]) -> None:
+        """The skip reason has to name the configured folder, or it is unactionable."""
+        repo = subject({".rhiza/.env": "SOURCE_FOLDER=nowhere\n"}, tag="v1.2.3")
+
+        result = repo.run("test_docstrings")
+
+        assert "No doctest folder found (looked for: nowhere)" in result.stdout, result.stdout
+
+    def test_the_environment_variable_overrides_the_env_file(self, subject: Callable[..., Subject]) -> None:
+        """``make rhiza-test`` sets ``RHIZA_DOCTEST_FOLDERS`` from the accumulated list.
+
+        Also the multi-folder and duplicate cases: the value is whitespace-separated and
+        ``src`` appears twice, which must not run the same folder's examples twice.
+        """
+        repo = subject(
+            {
+                ".rhiza/.env": "SOURCE_FOLDER=ignored\n",
+                "src/demopkg/__init__.py": PASSING_PACKAGE,
+                "utils/greet.py": PASSING_MODULE,
+            },
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_docstrings", env={"RHIZA_DOCTEST_FOLDERS": "src utils src missing"})
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "1 passed" in result.stdout, result.stdout
+
+    def test_a_configured_folder_that_does_not_exist_skips(self, subject: Callable[..., Subject]) -> None:
+        """A folder named but absent leaves nothing configured, which is the skip case."""
+        repo = subject({"src/demopkg/__init__.py": PASSING_PACKAGE}, tag="v1.2.3")
+
+        result = repo.run("test_docstrings", env={"RHIZA_DOCTEST_FOLDERS": "not-here"})
+
+        assert "No doctest folder found (looked for: not-here)" in result.stdout, result.stdout
+
+
+class TestDiscoveryPaths:
+    """Packages, namespace-nested packages and loose scripts are three different walks."""
+
+    def test_a_namespace_nested_package_is_discovered(self, subject: Callable[..., Subject]) -> None:
+        """``src/ns/pkg`` with no ``src/ns/__init__.py`` is still a package to walk."""
+        repo = subject({"src/ns/pkg/__init__.py": PASSING_PACKAGE}, tag="v1.2.3")
+
+        result = repo.run("test_docstrings")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "1 passed" in result.stdout, result.stdout
+
+    def test_loose_scripts_in_a_folder_without_an_init_are_run(self, subject: Callable[..., Subject]) -> None:
+        """A ``utils/`` of standalone scripts is what #1517 was about — no package walk reaches it."""
+        repo = subject({"utils/greet.py": PASSING_MODULE}, tag="v1.2.3")
+
+        result = repo.run("test_docstrings", env={"RHIZA_DOCTEST_FOLDERS": "utils"})
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "1 passed" in result.stdout, result.stdout
+
+    def test_a_folder_that_is_itself_a_package_is_left_to_the_package_walk(
+        self, subject: Callable[..., Subject]
+    ) -> None:
+        """With an ``__init__.py`` at its root the folder is a package, and is walked once."""
+        repo = subject(
+            {"pkgroot/__init__.py": PASSING_PACKAGE, "pkgroot/greet.py": PASSING_MODULE},
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_docstrings", env={"RHIZA_DOCTEST_FOLDERS": "pkgroot"})
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "1 passed" in result.stdout, result.stdout
+
+
+class TestFailureModes:
+    """A wrong example fails; a module that cannot be imported warns and is skipped."""
+
+    def test_a_wrong_example_fails_and_the_summary_names_the_module(self, subject: Callable[..., Subject]) -> None:
+        """The count in the summary is what makes the failure actionable.
+
+        Asserted against doctest's own report rather than the traceback: the summary is a
+        multi-line assertion message, and how much of one a traceback shows depends on the
+        pytest version — which would make this test measure the reporter.
+        """
+        repo = subject(
+            {"src/demopkg/__init__.py": PASSING_PACKAGE, "src/demopkg/wrong.py": FAILING_MODULE},
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_docstrings")
+
+        assert result.returncode != 0
+        assert "in demopkg.wrong" in result.stdout, result.stdout
+        assert "Doctest summary" in result.stdout, result.stdout
+
+    def test_an_unimportable_module_in_a_package_warns_rather_than_failing(
+        self, subject: Callable[..., Subject]
+    ) -> None:
+        """Being unable to measure an example is not the same as the example being wrong."""
+        repo = subject(
+            {
+                "src/demopkg/__init__.py": PASSING_PACKAGE,
+                "src/demopkg/absent.py": "import no_such_module_anywhere  # noqa: F401\n",
+            },
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_docstrings")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Could not import demopkg.absent" in result.stdout, result.stdout
+
+    def test_a_loose_script_that_raises_on_import_warns_rather_than_failing(
+        self, subject: Callable[..., Subject]
+    ) -> None:
+        """A standalone script may run code — or exit — at import time, which is not a defect here."""
+        repo = subject(
+            {"utils/greet.py": PASSING_MODULE, "utils/boom.py": 'raise SystemExit("scripts run on import")\n'},
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_docstrings", env={"RHIZA_DOCTEST_FOLDERS": "utils"})
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Could not import" in result.stdout, result.stdout
+
+    def test_a_source_folder_with_no_examples_at_all_skips(self, subject: Callable[..., Subject]) -> None:
+        """Docstrings without examples are not a failure — there is simply nothing to run."""
+        repo = subject({"src/demopkg/__init__.py": '"""A package with prose and no examples."""\n'}, tag="v1.2.3")
+
+        result = repo.run("test_docstrings")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "No doctests were found in any module" in result.stdout, result.stdout

--- a/tests/test_check_go_module.py
+++ b/tests/test_check_go_module.py
@@ -1,0 +1,287 @@
+"""Subject-repository tests for ``checks/test_go_module.py``.
+
+The Go check is the other one issue #10 flagged as shipping untested: nothing here is a
+Go module, so its 91 statements ran for the first time in a consumer's CI. What it
+asserts is the *wiring* around the version constant rather than the module's behaviour —
+that ``.bumpversion.toml`` still points at the one writable version location a Go tree
+has, and that the constant agrees with the tag.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import only for the fixture's type
+    from conftest import Subject
+
+SOUND_GO_MOD = """
+module example.com/demo
+
+go 1.23
+"""
+
+SOUND_VERSION_GO = """
+// Package version carries the module version the release flow rewrites.
+package version
+
+// Version is written by bump-my-version; see .bumpversion.toml. Mentioning 1.2.3 in
+// this comment is deliberate: an unanchored search would rewrite it too.
+const Version = "1.2.3"
+"""
+
+SOUND_BUMPVERSION = """
+[tool.bumpversion]
+allow_dirty = false
+commit = false
+tag = false
+tag_name = "v{new_version}"
+
+[[tool.bumpversion.files]]
+filename = "internal/version/version.go"
+search = 'const Version = "{current_version}"'
+replace = 'const Version = "{new_version}"'
+"""
+
+VERSION_GO = "internal/version/version.go"
+
+TOTAL_CHECKS = 12
+
+
+def _module(**extra: str) -> dict[str, str]:
+    """Return the file map for a sound Go module, with any extra files merged in.
+
+    Args:
+        extra: Additional repository-relative files, overriding the sound ones by name.
+
+    Returns:
+        The file map to hand to the ``subject`` factory.
+    """
+    return {
+        "go.mod": SOUND_GO_MOD,
+        VERSION_GO: SOUND_VERSION_GO,
+        ".bumpversion.toml": SOUND_BUMPVERSION,
+        **extra,
+    }
+
+
+class TestSoundSubject:
+    """A module carrying everything the check asks for passes all of it."""
+
+    def test_a_complete_module_passes_every_check(self, subject: Callable[..., Subject]) -> None:
+        """The reference case, and the only test here that proves the check can pass."""
+        repo = subject(_module(), tag="v1.2.3")
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert f"{TOTAL_CHECKS} passed" in result.stdout, result.stdout
+
+
+class TestGoMod:
+    """go.mod's presence and the directives the gates depend on."""
+
+    def test_a_repository_without_go_mod_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """No go.mod: the existence assertion fires and the directive tests skip."""
+        repo = subject(_module(**{"go.mod": ""}), tag="v1.2.3")
+        (repo.path / "go.mod").unlink()
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "go.mod not found at project root" in result.stdout, result.stdout
+
+    def test_a_go_mod_without_a_module_directive_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """Without ``module`` there is no import path, and nothing resolves the package."""
+        repo = subject(_module(**{"go.mod": "go 1.23\n"}), tag="v1.2.3")
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "declares no `module` directive" in result.stdout, result.stdout
+
+    def test_a_go_mod_without_a_go_directive_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """The directive sets the language version, which is what the deps gate reads."""
+        repo = subject(_module(**{"go.mod": "module example.com/demo\n"}), tag="v1.2.3")
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "declares no `go` directive" in result.stdout, result.stdout
+
+    def test_a_go_directive_below_the_deps_gate_floor_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """``go mod tidy -diff`` landed in 1.23; below it the gate fails on the flag, not the deps."""
+        repo = subject(_module(**{"go.mod": SOUND_GO_MOD.replace("go 1.23", "go 1.22")}), tag="v1.2.3")
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "which requires 1.23 or newer" in result.stdout, result.stdout
+
+
+class TestVersionConstant:
+    """The release flow's only writable version location must stay writable."""
+
+    def test_a_missing_version_file_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """A Go module has no manifest, so the constant is the whole story."""
+        repo = subject({"go.mod": SOUND_GO_MOD, ".bumpversion.toml": SOUND_BUMPVERSION}, tag="v1.2.3")
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "is the only version location in a Go" in result.stdout, result.stdout
+
+    def test_a_version_file_without_the_constant_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """The literal ``const Version = "..."`` is what .bumpversion.toml searches for."""
+        repo = subject(_module(**{VERSION_GO: 'package version\n\nvar Version = "1.2.3"\n'}), tag="v1.2.3")
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "declares no `const Version" in result.stdout, result.stdout
+
+    def test_a_constant_that_is_not_semver_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """``.bumpversion.toml``'s parse regex accepts MAJOR.MINOR.PATCH with an optional pre-release."""
+        repo = subject(_module(**{VERSION_GO: 'package version\n\nconst Version = "1.2"\n'}), tag="v1.2.3")
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "does not match the shape .bumpversion.toml parses" in result.stdout, result.stdout
+
+    def test_a_prerelease_constant_is_accepted(self, subject: Callable[..., Subject]) -> None:
+        """``1.2.3-rc.1`` is the one suffix the parse regex allows, so it must not be rejected."""
+        repo = subject(
+            _module(**{VERSION_GO: 'package version\n\nconst Version = "1.2.3-rc.1"\n'}),
+            tag="v1.2.3-rc.1",
+        )
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestBumpversionConfig:
+    """The shipped ``.bumpversion.toml`` must stay the config that wins, pointed at the constant."""
+
+    def test_no_config_anywhere_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """A Go module owns none of the four discoverable filenames, so go-core ships one."""
+        repo = subject({"go.mod": SOUND_GO_MOD, VERSION_GO: SOUND_VERSION_GO}, tag="v1.2.3")
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "No bumpversion config was found" in result.stdout, result.stdout
+        assert ".bumpversion.toml not found" in result.stdout, result.stdout
+
+    def test_a_leftover_cfg_toml_earns_the_extra_hint(self, subject: Callable[..., Subject]) -> None:
+        """``.rhiza/.cfg.toml`` is never auto-discovered; the failure should say so."""
+        repo = subject(
+            {
+                "go.mod": SOUND_GO_MOD,
+                VERSION_GO: SOUND_VERSION_GO,
+                ".rhiza/.cfg.toml": '[tool.bumpversion]\ncurrent_version = "1.2.3"\n',
+            },
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "A leftover .rhiza/.cfg.toml is present" in result.stdout, result.stdout
+
+    def test_an_unparseable_config_counts_as_absent(self, subject: Callable[..., Subject]) -> None:
+        """Malformed TOML cannot be the config that runs, so it is reported as missing."""
+        repo = subject(_module(**{".bumpversion.toml": "not = = toml\n"}), tag="v1.2.3")
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "No bumpversion config was found" in result.stdout, result.stdout
+
+    def test_a_second_config_in_pyproject_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """A pyproject.toml carried for tooling declares an inert table, and inert configs drift."""
+        repo = subject(
+            _module(**{"pyproject.toml": '[project]\nname = "helper"\n\n[tool.bumpversion]\ncommit = false\n'}),
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "also declares a bumpversion section" in result.stdout, result.stdout
+
+    def test_an_ini_config_is_detected_by_text(self, subject: Callable[..., Subject]) -> None:
+        """``.bumpversion.cfg`` is INI, so presence is a substring test rather than a TOML lookup."""
+        repo = subject(_module(**{".bumpversion.cfg": "[bumpversion]\ncurrent_version = 1.2.3\n"}), tag="v1.2.3")
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "'.bumpversion.cfg'" in result.stdout, result.stdout
+
+    def test_a_pinned_current_version_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """For Go the tag *is* the version, so pinning it in a synced file is pure drift."""
+        config = SOUND_BUMPVERSION.replace("[tool.bumpversion]", '[tool.bumpversion]\ncurrent_version = "1.2.3"')
+        repo = subject(_module(**{".bumpversion.toml": config}), tag="v1.2.3")
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "current_version is set in a file rhiza syncs" in result.stdout, result.stdout
+
+    def test_a_config_targeting_nothing_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """With no ``[[files]]`` entry the bump writes the new version nowhere at all."""
+        repo = subject(
+            _module(**{".bumpversion.toml": "[tool.bumpversion]\ncommit = false\ntag = false\n"}), tag="v1.2.3"
+        )
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert f"entry targets {VERSION_GO}" in result.stdout, result.stdout
+        assert "no version.go entry" in result.stdout, result.stdout
+
+    def test_an_unanchored_search_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """version.go's doc comment mentions the version, so a bare number rewrites prose."""
+        config = SOUND_BUMPVERSION.replace(
+            "search = 'const Version = \"{current_version}\"'", "search = '\"{current_version}\"'"
+        )
+        repo = subject(_module(**{".bumpversion.toml": config}), tag="v1.2.3")
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "is not anchored to the declaration" in result.stdout, result.stdout
+
+    def test_committing_and_tagging_from_the_bump_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """``/rhiza:release`` owns both; a config doing them adds a duplicate tag."""
+        config = SOUND_BUMPVERSION.replace("commit = false\ntag = false", "commit = true\ntag = true")
+        repo = subject(_module(**{".bumpversion.toml": config}), tag="v1.2.3")
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "must be false: the release flow commits and tags" in result.stdout, result.stdout
+
+
+class TestTagAgreement:
+    """The constant and the newest tag are one fact recorded twice."""
+
+    def test_a_constant_disagreeing_with_the_tag_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """Consumers resolve the module at the tag, so drift means an unfetchable version."""
+        repo = subject(_module(**{VERSION_GO: 'package version\n\nconst Version = "9.9.9"\n'}), tag="v1.2.3")
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode != 0
+        assert "would report a version that cannot be fetched" in result.stdout, result.stdout
+
+    def test_an_untagged_repository_skips_the_comparison(self, subject: Callable[..., Subject]) -> None:
+        """A module that has never released must not fail the version checks."""
+        repo = subject(_module())
+
+        result = repo.run("test_go_module")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "No version tags found" in result.stdout, result.stdout

--- a/tests/test_check_pyproject.py
+++ b/tests/test_check_pyproject.py
@@ -1,0 +1,323 @@
+"""Subject-repository tests for ``checks/test_pyproject.py``.
+
+Every test here builds a throwaway repository, runs the installed check against it with
+the command line a consumer uses, and asserts what the check *said*. The pairing is
+deliberate and is what issue #10 asked for: a sound subject proves the check passes
+something legitimate, and a broken subject proves it would have caught the defect. A
+check that only ever meets a sound subject is indistinguishable from one that asserts
+nothing.
+
+The count assertions matter as much as the exit statuses, for the reason
+``test_checks.py`` gives: a check module whose collection silently produced nothing
+reports success, and "0 passed" is the shape that failure takes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import only for the fixture's type
+    from conftest import Subject
+
+# A manifest that satisfies every assertion in the module. Deliberately spelled out in
+# full rather than built from the sound copy by mutation: the broken subjects below are
+# each one edit away from this, and that edit is the point of the test.
+SOUND_PYPROJECT = """
+[project]
+name = "demo"
+version = "1.2.3"
+description = "A demonstration project"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "MIT"
+authors = [{ name = "Demo Author" }]
+classifiers = ["Programming Language :: Python :: 3.11"]
+
+[project.urls]
+Homepage = "https://example.com/demo"
+Repository = "https://example.com/demo"
+
+[dependency-groups]
+test = ["pytest>=8.1"]
+
+[tool.bumpversion]
+allow_dirty = false
+commit = false
+tag = false
+"""
+
+# Every test in the module, for the sound case. Asserted as a number so that a check
+# lost to a collection change shows up here rather than passing quietly.
+TOTAL_CHECKS = 27
+
+
+class TestSoundSubject:
+    """A manifest carrying everything the check asks for passes all of it."""
+
+    def test_a_complete_manifest_passes_every_check(self, subject: Callable[..., Subject]) -> None:
+        """The reference case: nothing skipped, nothing failed."""
+        repo = subject({"pyproject.toml": SOUND_PYPROJECT, "README.md": "# Demo\n"}, tag="v1.2.3")
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert f"{TOTAL_CHECKS} passed" in result.stdout, result.stdout
+
+
+class TestMissingManifest:
+    """With no pyproject.toml the check reports its absence rather than skipping away."""
+
+    def test_a_repository_without_a_manifest_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """The existence assertion fires, and the rest skip on the missing file."""
+        repo = subject({"README.md": "# Demo\n"}, tag="v1.2.3")
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "pyproject.toml not found at project root" in result.stdout, result.stdout
+
+    def test_a_manifest_without_a_project_table_fails_loudly(self, subject: Callable[..., Subject]) -> None:
+        """``[project]`` missing is a failure, not a skip — the fixture calls fail()."""
+        repo = subject({"pyproject.toml": '[tool.other]\nkey = "value"\n'}, tag="v1.2.3")
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "missing a [project] table" in result.stdout, result.stdout
+
+
+class TestRequiredFields:
+    """The field assertions have to fail on a manifest that omits them."""
+
+    def test_a_manifest_missing_required_fields_reports_each_one(self, subject: Callable[..., Subject]) -> None:
+        """One failure per absent field, so the report names all of them at once."""
+        repo = subject({"pyproject.toml": '[project]\nname = "demo"\n'}, tag="v1.2.3")
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        for field in ("version", "description", "readme", "requires-python", "license", "authors"):
+            assert f"missing required field '{field}'" in result.stdout, result.stdout
+
+    def test_a_non_semver_version_is_rejected(self, subject: Callable[..., Subject]) -> None:
+        """``1.2`` is not MAJOR.MINOR.PATCH, whatever pip makes of it."""
+        repo = subject({"pyproject.toml": SOUND_PYPROJECT.replace('version = "1.2.3"', 'version = "1.2"')})
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "does not follow semver" in result.stdout, result.stdout
+
+    def test_blank_strings_do_not_count_as_present(self, subject: Callable[..., Subject]) -> None:
+        """A key whose value is whitespace is the same defect as a missing key."""
+        manifest = (
+            SOUND_PYPROJECT.replace('name = "demo"', 'name = "   "')
+            .replace('description = "A demonstration project"', 'description = "  "')
+            .replace('requires-python = ">=3.11"', 'requires-python = " "')
+            .replace('authors = [{ name = "Demo Author" }]', 'authors = [{ email = "nobody@example.com" }]')
+        )
+        repo = subject({"pyproject.toml": manifest})
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "must be a non-empty string" in result.stdout, result.stdout
+        assert "must have a non-empty 'name'" in result.stdout, result.stdout
+
+
+class TestOptionalTablesSkipRatherThanFail:
+    """Tables the check treats as optional must skip, and say so, not fail."""
+
+    def test_absent_urls_classifiers_and_groups_skip_their_tests(self, subject: Callable[..., Subject]) -> None:
+        """Three fixtures skip; the three assertions that *require* the tables still fire.
+
+        The asymmetry is the check's design, not an accident: ``[project.urls]`` being
+        absent is reported by ``test_urls_table_present`` while the two entry assertions
+        skip, because "no table" and "table without Homepage" are different defects.
+        """
+        manifest = """
+        [project]
+        name = "demo"
+        version = "1.2.3"
+        description = "A demonstration project"
+        readme = "README.md"
+        requires-python = ">=3.11"
+        license = "MIT"
+        authors = [{ name = "Demo Author" }]
+
+        [tool.bumpversion]
+        commit = false
+        tag = false
+        """
+        repo = subject({"pyproject.toml": manifest}, tag="v1.2.3")
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "missing a [project.urls] table" in result.stdout, result.stdout
+        # Homepage + Repository, the Python classifier, and the two dependency-group
+        # assertions: five skips behind three absent tables.
+        assert "5 skipped" in result.stdout, result.stdout
+
+    def test_empty_url_entries_are_rejected(self, subject: Callable[..., Subject]) -> None:
+        """A present-but-blank Homepage is worse than an absent one — it looks configured."""
+        manifest = SOUND_PYPROJECT.replace('Homepage = "https://example.com/demo"', 'Homepage = "  "')
+        repo = subject({"pyproject.toml": manifest}, tag="v1.2.3")
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "'Homepage' must be non-empty" in result.stdout, result.stdout
+
+    def test_a_deprecated_license_classifier_is_rejected(self, subject: Callable[..., Subject]) -> None:
+        """PyPI deprecated the trove classifiers in favour of the SPDX expression."""
+        manifest = SOUND_PYPROJECT.replace(
+            'classifiers = ["Programming Language :: Python :: 3.11"]',
+            'classifiers = ["Programming Language :: Python :: 3.11", "License :: OSI Approved :: MIT License"]',
+        )
+        repo = subject({"pyproject.toml": manifest}, tag="v1.2.3")
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "must not include any deprecated 'License :: ' entry" in result.stdout, result.stdout
+
+    def test_a_test_group_without_pytest_is_rejected(self, subject: Callable[..., Subject]) -> None:
+        """``make test`` has to find pytest somewhere, which is the group's only job."""
+        manifest = SOUND_PYPROJECT.replace('test = ["pytest>=8.1"]', 'test = ["coverage"]')
+        repo = subject({"pyproject.toml": manifest}, tag="v1.2.3")
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "must list pytest as a dependency" in result.stdout, result.stdout
+
+
+class TestBumpversionDiscovery:
+    """The #1453 family: bump-my-version must find the right config, not fall back."""
+
+    def test_no_config_anywhere_is_reported_with_the_search_list(self, subject: Callable[..., Subject]) -> None:
+        """The failure has to name the four filenames, since that list *is* the rule."""
+        manifest = SOUND_PYPROJECT.replace("[tool.bumpversion]\nallow_dirty = false\ncommit = false\ntag = false\n", "")
+        repo = subject({"pyproject.toml": manifest}, tag="v1.2.3")
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "no bumpversion config was found" in result.stdout, result.stdout
+        assert ".bumpversion.toml, .bumpversion.cfg, setup.cfg, pyproject.toml" in result.stdout, result.stdout
+
+    def test_a_leftover_cfg_toml_earns_the_extra_hint(self, subject: Callable[..., Subject]) -> None:
+        """``.rhiza/.cfg.toml`` predates the fix and is never discovered; say so."""
+        manifest = SOUND_PYPROJECT.replace("[tool.bumpversion]\nallow_dirty = false\ncommit = false\ntag = false\n", "")
+        repo = subject(
+            {"pyproject.toml": manifest, ".rhiza/.cfg.toml": '[tool.bumpversion]\ncurrent_version = "1.2.3"\n'},
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "A leftover .rhiza/.cfg.toml is present" in result.stdout, result.stdout
+
+    def test_a_toml_config_shadowing_pyproject_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """``.bumpversion.toml`` is searched first, which detaches the bump from the manifest."""
+        repo = subject(
+            {"pyproject.toml": SOUND_PYPROJECT, ".bumpversion.toml": "[tool.bumpversion]\ncommit = false\n"},
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "is searched before pyproject.toml" in result.stdout, result.stdout
+
+    def test_an_ini_config_shadowing_pyproject_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """The ``.cfg`` form is detected by text, since it is INI rather than TOML."""
+        repo = subject(
+            {"pyproject.toml": SOUND_PYPROJECT, ".bumpversion.cfg": "[bumpversion]\ncurrent_version = 1.2.3\n"},
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "'.bumpversion.cfg'" in result.stdout, result.stdout
+
+    def test_an_unparseable_config_counts_as_absent(self, subject: Callable[..., Subject]) -> None:
+        """Malformed TOML is not a shadowing config, so the sound manifest still wins.
+
+        The alternative reading — treating a file that cannot be parsed as present —
+        would report the *wrong* defect: the repo's problem is the broken file, and the
+        bumpversion table in pyproject.toml is genuinely still the one that runs.
+        """
+        repo = subject(
+            {"pyproject.toml": SOUND_PYPROJECT, ".bumpversion.toml": "this is not = = toml\n"},
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert f"{TOTAL_CHECKS} passed" in result.stdout, result.stdout
+
+    def test_a_stale_current_version_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """``current_version`` duplicates ``[project].version`` and then drifts from it."""
+        manifest = SOUND_PYPROJECT.replace(
+            "[tool.bumpversion]\nallow_dirty = false",
+            '[tool.bumpversion]\ncurrent_version = "1.0.0"\nallow_dirty = false',
+        )
+        repo = subject({"pyproject.toml": manifest}, tag="v1.2.3")
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "bumping from the stale value cannot match" in result.stdout, result.stdout
+
+    def test_committing_and_tagging_from_the_bump_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """``/rhiza:release`` owns both, so a config doing them adds a duplicate tag."""
+        manifest = SOUND_PYPROJECT.replace("commit = false\ntag = false", "commit = true\ntag = true")
+        repo = subject({"pyproject.toml": manifest}, tag="v1.2.3")
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "must be false: the release flow commits and tags" in result.stdout, result.stdout
+
+    def test_a_dynamic_version_skips_the_bump_assertions(self, subject: Callable[..., Subject]) -> None:
+        """With no static version there is no location to bump, so there is nothing to assert.
+
+        The manifest still fails overall — ``version`` is a required field and a dynamic
+        one is not declared here — but the three bump assertions skip with a reason
+        rather than judging a version that does not exist yet.
+        """
+        manifest = SOUND_PYPROJECT.replace('version = "1.2.3"', 'dynamic = ["version"]')
+        repo = subject({"pyproject.toml": manifest}, tag="v1.2.3")
+
+        result = repo.run("test_pyproject")
+
+        assert "dynamic \u2014 no static location to bump" in result.stdout, result.stdout
+
+
+class TestTagAgreement:
+    """The manifest version and the newest tag are one fact recorded twice."""
+
+    def test_a_version_disagreeing_with_the_tag_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """v1.2.3 against 9.9.9 is drift someone introduced by hand."""
+        manifest = SOUND_PYPROJECT.replace('version = "1.2.3"', 'version = "9.9.9"')
+        repo = subject({"pyproject.toml": manifest}, tag="v1.2.3")
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode != 0
+        assert "does not match" in result.stdout, result.stdout
+
+    def test_an_untagged_repository_skips_the_comparison(self, subject: Callable[..., Subject]) -> None:
+        """A project that has never released must not fail the version checks."""
+        repo = subject({"pyproject.toml": SOUND_PYPROJECT})
+
+        result = repo.run("test_pyproject")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "No version tags found" in result.stdout, result.stdout

--- a/tests/test_check_readme.py
+++ b/tests/test_check_readme.py
@@ -1,0 +1,186 @@
+"""Subject-repository tests for the two README checks.
+
+``checks/test_readme.py`` parses ``bash`` fences and never runs them;
+``checks/test_readme_validation.py`` *executes* ``python`` fences and diffs the output
+against the following ``result`` fence. The asymmetry is deliberate in the checks, and
+the tests keep it visible: a bash fence is documentation that must parse, a python fence
+is documentation that must be true.
+
+``tests/test_checks.py`` already covers the sound and broken bash cases end to end. What
+is here is everything a fence can be *besides* code — skipped, a directory tree, all
+comments — plus the whole of the python-fence half.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pytest_rhiza._fences import bash_usable
+
+if TYPE_CHECKING:  # pragma: no cover - import only for the fixture's type
+    from conftest import Subject
+
+
+class TestBashFenceExclusions:
+    """Three kinds of fence are not shell to be parsed, and each is excluded differently."""
+
+    def test_skipped_trees_and_comment_only_fences_are_all_excluded(self, subject: Callable[..., Subject]) -> None:
+        """One README carrying all three exclusions still passes.
+
+        Each fence here would fail ``bash -n`` if it reached it, so a pass is evidence
+        that all three exclusion paths fired rather than that the fences were benign.
+        """
+        if not bash_usable():
+            pytest.skip("no working `bash -n` on this platform")
+
+        readme = """
+        # Demo
+
+        Intentionally excluded, and not valid shell:
+
+        ```bash +RHIZA_SKIP
+        if then fi done esac
+        ```
+
+        A directory tree, which is not shell:
+
+        ```bash
+        src/
+        ├── demo
+        │   └── inner
+        └── other
+        ```
+
+        Only commentary, so there is nothing to parse:
+
+        ```bash
+        # install the project
+        # then run the tests
+        ```
+
+        And one fence that is real shell:
+
+        ```bash
+        make install
+        ```
+        """
+        repo = subject({"README.md": readme}, tag="v1.2.3")
+
+        result = repo.run("test_readme")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "3 passed" in result.stdout, result.stdout
+
+    def test_an_empty_readme_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """A file that exists but says nothing fails the readability assertion."""
+        repo = subject({"README.md": "   \n\n"}, tag="v1.2.3")
+
+        result = repo.run("test_readme")
+
+        assert result.returncode != 0
+        assert "README.md is empty" in result.stdout, result.stdout
+
+    def test_a_missing_readme_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """No README at all: the existence assertion fires before anything is parsed."""
+        repo = subject({"other.md": "# Not the readme\n"}, tag="v1.2.3")
+
+        result = repo.run("test_readme")
+
+        assert result.returncode != 0
+        assert "README.md not found at project root" in result.stdout, result.stdout
+
+
+class TestPythonFenceExecution:
+    """The python half runs the fence and diffs it against the documented result."""
+
+    def test_a_fence_matching_its_result_block_passes(self, subject: Callable[..., Subject]) -> None:
+        """The reference case, including a skipped fence that would raise if executed."""
+        readme = """
+        # Demo
+
+        ```python +RHIZA_SKIP
+        raise RuntimeError("this fence must never run")
+        ```
+
+        ```python
+        print("hello from the readme")
+        ```
+
+        ```result
+        hello from the readme
+        ```
+        """
+        repo = subject({"README.md": readme}, tag="v1.2.3")
+
+        result = repo.run("test_readme_validation")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "2 passed" in result.stdout, result.stdout
+
+    def test_output_disagreeing_with_the_result_block_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """A documented result that the code no longer produces is the defect this catches."""
+        readme = """
+        # Demo
+
+        ```python
+        print("what the code does")
+        ```
+
+        ```result
+        what the readme claims
+        ```
+        """
+        repo = subject({"README.md": readme}, tag="v1.2.3")
+
+        result = repo.run("test_readme_validation")
+
+        assert result.returncode != 0
+        assert "1 failed" in result.stdout, result.stdout
+
+    def test_a_fence_that_raises_is_reported_with_its_stderr(self, subject: Callable[..., Subject]) -> None:
+        """The exit status is checked before the diff, so the error is what gets reported."""
+        readme = """
+        # Demo
+
+        ```python
+        raise SystemExit("the example is broken")
+        ```
+
+        ```result
+        nothing
+        ```
+        """
+        repo = subject({"README.md": readme}, tag="v1.2.3")
+
+        result = repo.run("test_readme_validation")
+
+        assert result.returncode != 0
+        assert "README code exited with" in result.stdout, result.stdout
+
+    def test_a_fence_that_does_not_compile_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """Syntax is checked separately, so a fence nobody can run is still named."""
+        readme = """
+        # Demo
+
+        ```python
+        def broken(:
+        ```
+        """
+        repo = subject({"README.md": readme}, tag="v1.2.3")
+
+        result = repo.run("test_readme_validation")
+
+        assert result.returncode != 0
+        assert "has syntax error" in result.stdout, result.stdout
+
+    def test_a_readme_with_no_python_fences_passes(self, subject: Callable[..., Subject]) -> None:
+        """Nothing to execute is not a defect; the empty code and result strings agree."""
+        repo = subject({"README.md": "# Demo\n\nProse only.\n"}, tag="v1.2.3")
+
+        result = repo.run("test_readme_validation")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "2 passed" in result.stdout, result.stdout

--- a/tests/test_check_release_tags.py
+++ b/tests/test_check_release_tags.py
@@ -1,0 +1,72 @@
+"""Subject-repository tests for ``checks/test_release_tags.py``.
+
+The check exists because ``git tag --list`` happily reports a tag no branch contains,
+which is how a repository stays green while ``git describe`` disagrees with it. Testing it
+means building that state on purpose: a tag left behind on the pre-squash commit of a
+merged release branch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import only for the fixture's type
+    from conftest import Subject
+
+
+class TestReachability:
+    """A tag on a commit some branch contains, versus one orphaned by a squash merge."""
+
+    def test_a_tag_on_the_current_branch_passes(self, subject: Callable[..., Subject]) -> None:
+        """The ordinary case: the release was cut on the branch it lives on."""
+        repo = subject({"README.md": "# Demo\n"}, tag="v1.2.3")
+
+        result = repo.run("test_release_tags")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "1 passed" in result.stdout, result.stdout
+
+    def test_a_tag_no_branch_contains_is_reported(self, subject: Callable[..., Subject]) -> None:
+        """The squash-merge case, reconstructed: tag a commit, then move the branch off it.
+
+        This is what a squash-merged release branch leaves behind — the content lands on
+        the default branch under a new SHA while the tag stays on the pre-squash commit.
+        git-cliff then cannot place a changelog boundary at the tag, so regenerating
+        CHANGELOG.md deletes that version's section.
+        """
+        repo = subject({"README.md": "# Demo\n"})
+        base = repo.git("rev-parse", "HEAD").stdout.strip()
+        repo.write({"README.md": "# Demo\n\nRelease content.\n"})
+        repo.commit("release", tag="v2.0.0")
+        repo.git("reset", "--hard", base)
+
+        result = repo.run("test_release_tags")
+
+        assert result.returncode != 0
+        assert "which no branch contains" in result.stdout, result.stdout
+
+    def test_an_untagged_repository_skips(self, subject: Callable[..., Subject]) -> None:
+        """A project that has never released has nothing to be unreachable."""
+        repo = subject({"README.md": "# Demo\n"})
+
+        result = repo.run("test_release_tags")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "No version tags found" in result.stdout, result.stdout
+
+    def test_a_shallow_clone_skips_because_the_graph_is_incomplete(self, subject: Callable[..., Subject]) -> None:
+        """CI clones shallowly by default, and reachability cannot be judged from a truncated graph.
+
+        Without this branch the check would fail every shallow CI run — the tagged commit
+        is present but no branch in the clone contains it — which is the false positive
+        that would get the whole check disabled.
+        """
+        origin = subject({"README.md": "# Demo\n"}, tag="v1.2.3")
+        clone = subject(git=False)
+        clone.git("clone", "--quiet", "--depth", "1", "--branch", "v1.2.3", origin.path.as_uri(), ".")
+
+        result = clone.run("test_release_tags")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "shallow clone" in result.stdout, result.stdout

--- a/tests/test_fences.py
+++ b/tests/test_fences.py
@@ -102,6 +102,7 @@ class TestBashUsable:
         bash_usable.cache_clear()
 
         def _silent_failure(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            """Stand in for a bash that exits non-zero saying nothing at all."""
             return subprocess.CompletedProcess(args=["bash", "-n"], returncode=1, stdout="", stderr="")
 
         monkeypatch.setattr(_fences.subprocess, "run", _silent_failure)

--- a/uv.lock
+++ b/uv.lock
@@ -216,14 +216,14 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "packaging", specifier = ">=24.0" },
-    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest", specifier = ">=8.1" },
     { name = "pytest-timeout", specifier = ">=2.3" },
     { name = "python-dotenv", specifier = ">=1.0" },
 ]
 
 [package.metadata.requires-dev]
 test = [
-    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest", specifier = ">=8.1" },
     { name = "pytest-cov", specifier = ">=6.0" },
 ]
 


### PR DESCRIPTION
Adopts four workflow stubs from `jebel-quant/rhiza@v1.4.2` and fixes every gate that was red on arrival — including the two that were initially filed as follow-ups rather than fixed here.

## Why this works without adopting the template

Rhiza v1.4.0 retired the synced make layer. The reusable workflows no longer call `make <gate>` — they call `uvx rhiza-task <gate>`, and `rhiza-task` is a standalone CLI that resolves its settings from `[tool.rhiza-task]`, `.rhiza/.env` and the environment. The reusable `rhiza_ci.yml` says so directly:

> `make <gate>` was the old interface, and v1.4.0 retired the synced make layer — core ships no Makefile and no `.rhiza/rhiza.mk` … Calling the CLI directly drops the dependency on a front door this workflow does not ship.

Verified before adopting: `rhiza-task` resolves `source_folder = src` and `coverage_fail_under = 90` against this tree, which has no `.rhiza/` directory at all. Both defaults now hold, so no `[tool.rhiza-task]` table is needed.

## What is added

| file | delegates to |
| --- | --- |
| `rhiza_ci.yml` | test+coverage, typecheck, deptry, security, docs-coverage, license, lowest-deps, rhiza-test, pre-commit |
| `rhiza_codeql.yml` | CodeQL scanning — push, PR, weekly |
| `rhiza_scorecard.yml` | OpenSSF Scorecard — weekly and on branch-protection change |
| `rhiza_weekly.yml` | fresh-resolution dependency compatibility, README link check |

All four pinned at `@v1.4.2`.

## The four fixes

**`docs-coverage`** was 99.3% against a 100% bar — a single missing docstring, on the `_silent_failure` closure in `tests/test_fences.py`. Now 100.0% over 262 items. Note the bar includes `tests/`, which is stricter than most projects set.

**`deps`** reported three issues, and the `python-dotenv` mapping turned out to be load-bearing rather than cosmetic. deptry infers the module name `python_dotenv`, then reports the declared package as unused *and* the import as undeclared — one wrong guess counted twice. `pytest-timeout` is genuinely invisible to deptry, being consumed through its `pytest11` entry point rather than imported. Both entries are mappings, not suppressions of a real gap.

**`lowest-deps`** — the interesting one, and worth reading past the diff. The job earned its place on day one by finding a real defect at a dependency floor this package advertises: at `pytest>=8.0` on ubuntu, `tests/test_checks.py` collected **zero** tests and died with `PermissionError: '/home/packer/__init__.py'`.

The mechanism. `--pyargs` is this package's whole interface, so the modules under collection live in site-packages while the repository under test does not — two unrelated directory trees. Up to and including 8.0.2, `Session.collect` walked the *generic* ancestor chain of a `--pyargs` argument, stripped the ancestors shared with `confcutdir`, and then **fully scanned** the first directory that remained. With rootdir under `/tmp/pytest-of-runner/…` and the argument under `/home/runner/…`, that directory is `/home` — and `/home/packer` is not stat-able by `runner`, so `pytest_collect_directory`'s `pkginit.is_file()` raised.

Reproduced locally, since neither macOS nor a same-tree layout reproduces it on its own: put rootdir and the installed package in *disjoint* subtrees with an unreadable sibling next to the package, and pytest 8.0.0 produces the identical failure down to the node-id shape — `ERROR ::B` against CI's `ERROR ::home`. Bisected across 8.0.0 / 8.0.1 / 8.0.2 (all fail) and 8.1.0 onwards (all pass); 8.1.0 is the release that added a `--pyargs`-specific branch, commented in `_pytest/main.py` as

> For --pyargs arguments, only consider paths matching the module name. Paths beyond the package hierarchy are not included.

So the floor is corrected rather than the collection worked around: the package genuinely does not work at `>=8.0`, and this is a failure mode every rhiza-managed consumer inherits, not a quirk of our own suite. `pytest>=8.1` in both the runtime dependencies and the `test` group. (In practice that resolves to 8.1.1 — 8.1.0 was yanked from PyPI.)

**`test`** — the coverage gate, which was reporting 5.71% against a 90 threshold. The number was not a measurement of anything: **no quantity of new tests would have moved it.** A check module is exercised by an inner `pytest --pyargs` command line in a subprocess and is never imported by the outer suite, so a coverage run watching only the parent process sees all of `src/pytest_rhiza/checks/` at 0% however thoroughly it is tested. Two things were therefore needed, in this order:

1. **Make the measurement real.** `[tool.coverage.run] patch = ["subprocess"]` makes coverage inject its start-up into every child the suite spawns. On the unchanged suite that alone moved the number from 5.71% to 15%, which is the honest reading of what 18 tests covered.
2. **Then write the tests** #10 asked for. Five check modules — `test_pyproject`, `test_cargo_toml`, `test_docstrings`, `test_go_module`, `test_readme_validation`, 478 of 578 statements — had zero exercise. Each now gets a sound subject repository plus a broken subject per assertion, built under `tmp_path` and judged through the real consumer command line.

**18 tests → 105. 5.71% → 98.96%.** Every check module is at 96–100%; the six remaining uncovered statements are two platform-specific skips (`no working bash -n`, reachable only on a Windows runner) and one defensive `except ImportError` the inner walk already swallows.

The harness for this lives in `tests/conftest.py` as a `subject` factory — write files, `git init`, tag, run the checks — and `tests/test_checks.py`'s existing `_run_checks` pattern is what it generalises. Deliberately *not* `pytester`: that drives an in-process run over files it writes itself, which is a different code path from the one every rhiza-managed repo actually uses.

## A defect the new tests found

`checks/test_docstrings.py` crashed on a configured folder that is *itself* a package — a flat-layout project setting `SOURCE_FOLDER` to its package name, rather than to a directory containing packages. The module name for that folder's `__init__.py` was derived relative to the folder itself, yielding `""`, and `importlib.import_module("")` raises `ValueError` — which is not the `ImportError` the walk catches. So the gate died with `ValueError: Empty module name` instead of reporting anything at all. Module names are now resolved against the folder's parent in that case, which is where they are importable from.

This is the second pre-existing defect surfaced by work in this PR, and both were surfaced the same way: by running code that had never been run.

## Two deliberate choices

**`ci.yml` is kept, not replaced.** `rhiza-task ci-os-matrix` resolves to `["ubuntu-latest"]` here, while `ci.yml` runs 3 OS × 4 Python. That Windows leg is what justifies `_fences.bash_usable()` existing — it was written for WSL's `bash.exe` exiting non-zero in silence. `ci-os-matrix` was deliberately *not* declared in `[tool.rhiza-task]`, which would duplicate twelve jobs across two workflows. The cost is that `ci.yml` and `rhiza_ci.yml` overlap on the ubuntu test leg.

**pip-audit is added to `ci.yml`, not to a stub.** `rhiza-task security` is bandit only (`uvx bandit -r src -ll -q`) — it scans this repo's source and never inspects dependencies, so nothing in the adopted stubs does CVE scanning. It goes in the repo-owned workflow because the stubs track upstream and should not be edited locally. Clean against the current lock.

## Gate board

Every gate `rhiza_ci.yml` invokes, run locally against this branch:

| gate | before | after |
| --- | --- | --- |
| `typecheck` | PASS | PASS |
| `security` | PASS | PASS |
| `license` | — | PASS |
| `rhiza-test` | — | PASS (34) |
| `docs-coverage` | FAIL 99.3% | **PASS 100%** |
| `deps` | FAIL (3) | **PASS** |
| `lowest-deps` | FAIL (4 failed, 0 collected) | **PASS (105)** |
| `test` | FAIL 5.71% | **PASS 98.96%** |

`make lint` clean, `make test` 105/105, self-checks 34/34.

## The coverage threshold now lives in one place

Issue #11's other half: `pytest-cov` was declared and never used, so neither `make test` nor `ci.yml` measured anything. Both now run `--cov=src --cov-report=term-missing --cov-fail-under=90`, the same flags and the same number `rhiza-task test` passes. `--cov=src` rather than `--cov=pytest_rhiza` so the three agree exactly.

Closes #10, #11, #15, #18, #19, #20, #23.

## Two things worth a second opinion in review

**`rhiza-test` tests this repo against a published older copy of itself.** Its run reports `plugins: rhiza-0.2.0` — `rhiza-task` pins `pytest-rhiza==0.2.0` from PyPI, while this tree is 0.2.2. So the job validates the repo using a released build rather than the code under review, and a regression in `src/` would not fail it. Fine as a conformance check, misleading as a self-test. Unaffected by this PR, but more visible now that the suite it shadows is 105 tests rather than 18.

**`mypy --strict` is not enabled.** rhiza-task's `typecheck` runs `ty` *and* `mypy --strict`, but mypy only engages when configured. `mypy --strict src` currently reports 56 errors in 6 files, nearly all `Missing type arguments for generic type "dict"` in the check modules. No `[tool.mypy]` was added, because committing one would turn the newly-adopted `typecheck` job red on its first run. `ty` passes clean and is what gates the branch.

Separately, and not fixed here: `src/pytest_rhiza/__init__.py` still declares `__version__ = "0.1.0"` against `[project].version = "0.2.2"`. Its own comment says a `[[tool.bumpversion.files]]` entry is needed for that file — and there isn't one, which is why it is stale. Nothing reads `__version__` today, so it is a latent trap rather than a live bug, and it belongs in a release-flow change rather than a CI one.
