### PR TITLE
fix: SHA-pin ci.yml's actions (#21) and de-stale the README pin (#17)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,85 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Configuration: Dependabot
+#
+# Purpose: Automate dependency updates for Python packages, GitHub Actions, and Docker images.
+#
+# Documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Adopted verbatim from the template, like the rhiza_*.yml workflow stubs. It was never
+# synced here because this repository carries no .rhiza/ pointer, which is why the
+# github-actions ecosystem below had nothing keeping ci.yml current — and why the SHA
+# pins added alongside it would otherwise have gone stale unnoticed.
+
+version: 2
+updates:
+  # Python dependencies using uv
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "Asia/Dubai"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "Asia/Dubai"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # Docker
+  #- package-ecosystem: "docker"
+  #  directory: "/docker"
+  #  schedule:
+  #    interval: "weekly"
+  #    day: "tuesday"
+  #    time: "09:00"
+  #    timezone: "Asia/Dubai"
+  #  open-pull-requests-limit: 10
+  #  labels:
+  #    - "dependencies"
+  #    - "docker"
+  #  commit-message:
+  #    prefix: "chore(deps)"
+  #    include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,18 @@
 name: CI
 
+# Third-party actions are SHA-pinned, with the human-readable version in the trailing
+# comment. A tag is a mutable ref — even an exact one like `v10.0.1` — so pinning to it
+# leaves the code that runs in CI changeable by its owner with no commit here. The SHA is
+# the only immutable form; the trailing comment is what keeps it reviewable, and
+# .github/dependabot.yml is what keeps the two moving together. Pinning without an
+# updater only trades a mutable ref for a stale one, so the two arrive together.
+#
+# Separately, `astral-sh/setup-uv` could not have used a floating major in any case: it
+# publishes no `v8`, `v9` or `v10` alias tag, so `@v10` does not resolve at all.
+#
+# `.github/workflows/rhiza_*.yml` are upstream files from jebel-quant/rhiza, so pinning
+# them belongs upstream and is filed as Jebel-Quant/rhiza#1577 rather than patched here.
+
 on:
   push:
     branches: [main]
@@ -20,11 +33,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Exact version, not a floating major: astral-sh/setup-uv publishes no `v8`,
-      # `v9` or `v10` alias tag, so `@v10` fails to resolve at job start.
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
 
@@ -48,11 +59,9 @@ jobs:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Exact version, not a floating major: astral-sh/setup-uv publishes no `v8`,
-      # `v9` or `v10` alias tag, so `@v10` fails to resolve at job start.
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -80,11 +89,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Exact version, not a floating major: astral-sh/setup-uv publishes no `v8`,
-      # `v9` or `v10` alias tag, so `@v10` fails to resolve at job start.
-      - uses: astral-sh/setup-uv@v10.0.1
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: true
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,18 @@ goes red instead of quietly skipping.
 RHIZA_CHECKS ?= pytest_rhiza.checks.test_readme pytest_rhiza.checks.test_release_tags
 
 rhiza-test: install ## run the rhiza repository checks
-	@${UV_BIN} run --with 'pytest-rhiza==0.1.0' pytest --pyargs ${RHIZA_CHECKS}
+	@${UV_BIN} run --with 'pytest-rhiza==<version>' pytest --pyargs ${RHIZA_CHECKS}
 ```
+
+`<version>` is a placeholder, not a value to copy. The sync generates the pin from the
+template release — see [Version pinning](#two-things-still-to-decide) — so the number that
+lands in a consumer's `quality.mk` is never written by hand here. It is also spelled this
+way because a literal cannot survive: nothing bumps this file (there is no
+`[[tool.bumpversion.files]]` entry for it) and nothing checks it either — a ```` ```make ````
+fence is reported by the docs check as *skipped — make fences are not checkable*, and the
+README's `bash` fences are only parsed by `bash -n`, never resolved against reality. The
+pin here read `0.1.0` for three releases for exactly that reason. `tests/test_readme_pin.py`
+is now the thing that notices.
 
 `python-core`'s `python.mk` appends its own, and `rust-core` / `go-core` / `tests` do the
 same with theirs:

--- a/tests/test_readme_pin.py
+++ b/tests/test_readme_pin.py
@@ -1,0 +1,65 @@
+"""The README must not pin this package to a literal version.
+
+Issue #17: `README.md` documented the make fragment consumers adopt, pinning
+`pytest-rhiza==0.1.0` while the package was at 0.2.2 — three releases stale, and stale
+for a structural reason rather than an oversight. Nothing bumps the file (there is no
+`[[tool.bumpversion.files]]` entry for `README.md`) and nothing reads it either: the
+fragment sits in a ``` ```make ``` fence, which the docs check reports as *skipped — make
+fences are not checkable*, and the README's `bash` fences are only parsed by `bash -n`.
+
+So the fix was to stop writing a number there at all — the sync generates the pin from
+the template release, which is what the README's own "Version pinning" note says. This
+test is what makes that decision hold: a literal reintroduced by a well-meaning edit
+fails here rather than going stale for another three releases.
+
+Deliberately a *prohibition* rather than an equality check against the current version.
+Asserting the number matches would keep a literal in the file and just move the staleness
+into a test that has to be updated on every release — a worse trade, and the same trap in
+a new place.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# `pytest-rhiza==` followed by anything digit-led: the shape a copied literal takes.
+# Normalising the separator first means `pytest_rhiza==`, `~=` and `>=` are caught too.
+_PINNED_LITERAL = re.compile(r"pytest[-_]rhiza\s*(?:==|~=|>=)\s*v?\d")
+
+README = Path(__file__).resolve().parents[1] / "README.md"
+
+
+def test_the_readme_pins_no_literal_version() -> None:
+    """The documented make fragment must use a placeholder, not a version number."""
+    text = README.read_text(encoding="utf-8")
+
+    offenders = [
+        f"line {number}: {line.strip()}"
+        for number, line in enumerate(text.splitlines(), start=1)
+        if _PINNED_LITERAL.search(line)
+    ]
+
+    assert not offenders, (
+        "README.md pins pytest-rhiza to a literal version:\n"
+        + "\n".join(offenders)
+        + "\n\nUse a placeholder such as `pytest-rhiza==<version>` instead. The sync "
+        "generates the real pin from the template release, and nothing in this repository "
+        "bumps or checks a number written here — which is how it came to read 0.1.0 three "
+        "releases after 0.1.0 (#17)."
+    )
+
+
+def test_the_placeholder_is_still_there() -> None:
+    """The prohibition above passes vacuously if the fragment is deleted or renamed.
+
+    Cheap, and it is the failure mode a negative assertion always has: a test that only
+    says "no literal" is satisfied by a README that no longer documents the wiring at all.
+    """
+    text = README.read_text(encoding="utf-8")
+
+    assert "pytest-rhiza==<version>" in text, (
+        "README.md no longer shows the `pytest-rhiza==<version>` pin in the make fragment. "
+        "If the fragment moved or was rewritten, update this test to match — it is the only "
+        "thing keeping a literal version out of that file."
+    )


### PR DESCRIPTION
Two unrelated findings from the `/rhiza:quality` sweep, one commit each so they can be reviewed — or reverted — independently.

## #21 — SHA-pin the actions in `ci.yml`

`ci.yml` used `actions/checkout@v7`, a **moving major**: the code that checks out this repo could change under CI with no commit here. `astral-sh/setup-uv@v10.0.1` was an exact tag, which is much better, but a tag is still a ref its owner can repoint.

Both are now pinned to the tag's commit SHA with the version in a trailing comment — the pattern `rhiza_release.yml` already uses once, for `configure-git-auth`:

```yaml
- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
- uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
```

The three-times-repeated `setup-uv` rationale is collapsed into one policy note at the top of the file, which is also where the `@v10`-does-not-resolve caveat now lives.

### Why a dependabot config comes with it

**SHA-pinning on its own would have made this repo worse, not better.** An immutable ref with nothing watching it is a dependency that silently stops receiving security fixes — you trade a mutable ref for a stale one. Pinning is only maintainable next to an updater.

The template already ships `.github/dependabot.yml` covering the `uv` and `github-actions` ecosystems. It is absent here for the same structural reason the workflow stubs were absent before #22: this repo carries no `.rhiza/` pointer, so no sync ever delivered it. Adopted verbatim, headers and all, exactly as the `rhiza_*.yml` stubs were.

This is the one part of the PR that is not strictly in the issue's "done when", so it is the easy thing to drop if you would rather not take weekly Dependabot PRs — it is self-contained in the same commit. My argument for keeping it: `rhiza_scorecard.yml` scores both `Pinned-Dependencies` and `Dependency-Update-Tool`, and this PR only satisfies the first without it.

### `rhiza_release.yml` is deliberately untouched

The issue flagged it as the higher-value target and asked to confirm before editing — correctly. It is synced from `jebel-quant/rhiza` and **cannot** be a stub, because PyPI's OIDC validates the exact workflow path, so it is copied verbatim into every managed repo. Patching it here would be local drift from upstream, and would fix one repo's copy of a problem that exists in all of them.

Filed upstream instead as **Jebel-Quant/rhiza#1577**, with the full inventory: nine distinct third-party actions on mutable tags, in a workflow holding `id-token: write` and publishing via Trusted Publishing. Upstream already has a `dependabot.yml` covering `github-actions`, so the fix is maintainable there.

## #17 — the README pin

`README.md` documented the make fragment consumers adopt as `pytest-rhiza==0.1.0`, while the package is at 0.2.2. Three releases stale.

Now a placeholder — `pytest-rhiza==<version>` — which is the "cannot go stale" option the issue offered, and the one the README's own *Version pinning* note already implies: the sync **generates** the pin from the template release, so the number reaching a consumer's `quality.mk` was never the one hand-written here.

Writing `0.2.2` instead would be stale again at the next release, and the reason it went stale in the first place is structural rather than an oversight:

- nothing bumps the file — there is no `[[tool.bumpversion.files]]` entry for `README.md`;
- nothing reads it — the fragment is a ```` ```make ```` fence, which the docs check reports as *skipped — make fences are not checkable*, and the README's `bash` fences are only parsed by `bash -n`, never resolved against reality.

So `tests/test_readme_pin.py` is now what notices: it fails on any literal `pytest-rhiza==<number>` reintroduced there, with a companion assertion so the prohibition cannot pass vacuously by the fragment being deleted or renamed. I checked both actually bite by reintroducing `0.2.2` and watching them fail, rather than trusting a negative test that has never been red.

A prohibition rather than an equality check against the current version, deliberately: asserting the number *matches* keeps a literal in the file and relocates the staleness into a test that has to be bumped every release — the same trap in a new place.

## Verification

`make lint` clean; all seven `rhiza-task` gates pass locally (`typecheck`, `deps`, `docs-coverage`, `security`, `license`, `rhiza-test`, `test`); 107 tests, coverage 98.96%.

Closes #17, closes #21.