### PR TITLE
fix: doctest the folder under test, not a same-named installed package

### DIFF
--- a/src/pytest_rhiza/checks/test_docstrings.py
+++ b/src/pytest_rhiza/checks/test_docstrings.py
@@ -30,6 +30,7 @@ import doctest
 import importlib
 import importlib.util
 import os
+import sys
 import warnings
 from pathlib import Path
 
@@ -63,13 +64,58 @@ def _iter_modules_from_path(logger, package_path: Path, src_path: Path):
 
 
 def _find_packages(src_path: Path):
-    """Find all packages in the source path, including those nested under namespace packages."""
-    for init_file in src_path.rglob("__init__.py"):
+    """Find all packages in the source path, including those nested under namespace packages.
+
+    Sorted, like :func:`_iter_loose_modules` already sorts its files: ``rglob`` yields in
+    filesystem order, so without this the packages are doctested in an order that varies
+    between machines — and one package importing another makes that order observable.
+    """
+    for init_file in sorted(src_path.rglob("__init__.py")):
         package_dir = init_file.parent
         # Only yield top-level packages (those whose parent doesn't have __init__.py or is src_path)
         parent = package_dir.parent
         if parent == src_path or not (parent / "__init__.py").exists():
             yield package_dir
+
+
+def _evict_shadowing_package(monkeypatch, logger, import_root: Path, package_dir: Path) -> None:
+    """Drop a same-named package already imported from somewhere other than this folder.
+
+    Without this the gate can report a pass having measured code that is not in the tree.
+    ``importlib.import_module`` resolves a submodule against the *already-imported*
+    parent's ``__path__``, and prepending a folder to ``sys.path`` does not change a
+    parent that is in ``sys.modules`` already. So where a package under the configured
+    folder shares its top-level name with an installed distribution, the installed copy is
+    what gets doctested — silently, and reported as a skip when it happens to carry no
+    examples.
+
+    That is not hypothetical for pytest-rhiza itself, which is always installed (it is the
+    plugin running this check), so for three releases its own new modules were invisible
+    here. Any project whose source package name collides with something in its environment
+    inherits the same hole.
+
+    Args:
+        monkeypatch: The test's monkeypatch fixture, so ``sys.modules`` is restored at
+            teardown rather than left mutated for the rest of the session.
+        logger: The test logger.
+        import_root: The directory prepended to ``sys.path`` for this folder.
+        package_dir: The package about to be walked.
+    """
+    top_level = package_dir.relative_to(import_root).parts[0]
+    existing = sys.modules.get(top_level)
+    if existing is None:
+        return
+    located = [Path(entry).resolve() for entry in getattr(existing, "__path__", [])]
+    if (import_root / top_level).resolve() in located:
+        return  # already the folder under test; nothing is being shadowed
+    logger.info(
+        "Evicting cached package %s (imported from %s) so %s is what gets measured",
+        top_level,
+        [str(path) for path in located] or "an unknown location",
+        import_root / top_level,
+    )
+    for cached in [name for name in list(sys.modules) if name == top_level or name.startswith(f"{top_level}.")]:
+        monkeypatch.delitem(sys.modules, cached, raising=False)
 
 
 def _doctest_folders(root: Path, values: dict) -> list[Path]:
@@ -188,6 +234,7 @@ def test_doctests(logger, root, monkeypatch: pytest.MonkeyPatch, capsys: pytest.
                 # Import the package
                 package_name = package_dir.name
                 logger.info("Discovered package: %s", package_name)
+                _evict_shadowing_package(monkeypatch, logger, import_root, package_dir)
                 try:
                     modules = list(_iter_modules_from_path(logger, package_dir, import_root))
                     logger.debug("%d module(s) found in package %s", len(modules), package_name)

--- a/tests/test_check_docstrings.py
+++ b/tests/test_check_docstrings.py
@@ -30,6 +30,20 @@ Examples:
 """
 '''
 
+# Imports its sibling, so that by the time the walk reaches `beta` it is already in
+# sys.modules — resolved from the folder under test, which is the case eviction must not
+# disturb. Discovery is sorted, so `alpha` reliably comes first.
+IMPORTS_A_SIBLING = '''
+"""A package that imports its sibling.
+
+Examples:
+    >>> 1
+    1
+"""
+
+import beta  # noqa: F401
+'''
+
 PASSING_MODULE = '''
 """A demonstration module.
 
@@ -213,6 +227,48 @@ class TestFailureModes:
 
         assert result.returncode == 0, result.stdout + result.stderr
         assert "Could not import" in result.stdout, result.stdout
+
+    def test_a_package_shadowed_by_an_installed_distribution_is_still_measured(
+        self, subject: Callable[..., Subject]
+    ) -> None:
+        """The folder under test wins over a same-named package already imported.
+
+        ``dotenv`` is the sharpest case available: the check module imports it itself, so
+        it is guaranteed to be in ``sys.modules`` before the walk starts. Without the fix
+        ``import_module("dotenv")`` returns the *installed* python-dotenv and the subject's
+        own package is never opened — the gate reports a pass having measured somebody
+        else's code, which is the failure mode that hid this for three releases of
+        pytest-rhiza's own ``_bumpversion`` module.
+        """
+        repo = subject({"src/dotenv/__init__.py": FAILING_MODULE}, tag="v1.2.3")
+
+        result = repo.run("test_docstrings")
+
+        assert result.returncode != 0, result.stdout + result.stderr
+        assert "Doctest summary" in result.stdout, result.stdout
+
+    def test_a_package_already_imported_from_the_folder_is_left_alone(self, subject: Callable[..., Subject]) -> None:
+        """Eviction must not fire when the cached package is *already* the right one.
+
+        ``alpha`` imports ``beta``, so by the time the walk reaches ``beta`` it is in
+        ``sys.modules`` — resolved from the folder under test, which is the case eviction
+        must leave alone. Dropping and re-importing it there would be pointless work at
+        best, and at worst would re-run import-time code that ``alpha`` is holding a
+        reference to. Package discovery is sorted, which is what makes ``alpha`` reliably
+        come first.
+        """
+        repo = subject(
+            {
+                "src/alpha/__init__.py": IMPORTS_A_SIBLING,
+                "src/beta/__init__.py": PASSING_MODULE,
+            },
+            tag="v1.2.3",
+        )
+
+        result = repo.run("test_docstrings")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "1 passed" in result.stdout, result.stdout
 
     def test_a_source_folder_with_no_examples_at_all_skips(self, subject: Callable[..., Subject]) -> None:
         """Docstrings without examples are not a failure — there is simply nothing to run."""


### PR DESCRIPTION
Fixes the warning I flagged on #28 — but the warning turned out to be the visible tip of a defect that makes the docstring gate **report a pass having measured code that is not in the tree**.

## The bug

`importlib.import_module` resolves a submodule against the *already imported* parent's `__path__`. Prepending a folder to `sys.path` does not displace a parent that is already in `sys.modules`. So where a package under the configured folder shares its top-level name with something installed, the installed copy is what gets doctested.

For pytest-rhiza this is not a corner case, it is the normal state: the package is always installed, because it is the plugin running the check. **Every module added to `src/pytest_rhiza/` since 0.2.0 has been invisible to its own docstring gate**, which surfaced only as

```
UserWarning: Could not import pytest_rhiza._bumpversion: No module named 'pytest_rhiza._bumpversion'
```

A warning — so the gate stayed green while measuring nothing. Any project whose source package name collides with something in its environment inherits the same hole.

## The fix

`_evict_shadowing_package` drops the cached `sys.modules` entries for that top-level name, through `monkeypatch.delitem` so they are restored at teardown, and **only** when the cached package resolves somewhere other than the folder under test. Where it is already the right one — the ordinary editable install — nothing is touched.

## Proved in both directions, because a green gate proves nothing here

The new subject test uses `dotenv`, which is the sharpest case available: the check module imports it itself, so it is guaranteed to be in `sys.modules` before the walk starts. With a failing doctest in the subject's own `src/dotenv/`:

- **before:** `No doctests were found in any module` → skipped, gate green. This is the silent-pass in miniature.
- **after:** fails, naming the module.

A second test covers the leave-it-alone branch. And locally, `pytest --pyargs pytest_rhiza.checks.test_docstrings` now catches a doctest deliberately broken in `_bumpversion.py`, which it did not before.

`_find_packages` now sorts, matching `_iter_loose_modules` which already did. `rglob` yields in filesystem order, so walk order varied between machines — unobservable until one package imports another, which is exactly what the leave-it-alone test needs in order to be deterministic.

## What this does *not* fix, and one trap to avoid

The `rhiza-test` gate runs the checks from a pinned `pytest-rhiza @ v0.2.0`, so it keeps using the old check code — and emitting the warning — until a release ships. That is the other half, and it is upstream: **[Jebel-Quant/rhiza#1578](https://github.com/Jebel-Quant/rhiza/issues/1578)**.

Worth stating plainly because it looks like a one-line local fix: **`[tool.rhiza-task] pytest_rhiza = "."` is a trap.** It appears to work — warning gone, 34/34 pass — but `uv run --with .` resolves to a *cached built copy* under `~/.cache/uv/archive-v0/`, not the working tree, and it does not rebuild on edit. I planted a sentinel in a source file, re-ran, and grep'd the installed copy: absent, same archive hash. A deliberately broken doctest was not caught. So the override silences the symptom while measuring a different and now *stale* copy — worse than the honest `@v0.2.0` pin, which at least declares what it is. Not used here.

## Verification

`make lint` clean; `typecheck`, `docs-coverage`, `rhiza-test` (34/34) and `test` all pass; 109 tests; coverage 99%, with the new branch covered.