### PR TITLE
docs: describe the rhiza-task integration, not the retired make layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,40 +74,60 @@ resolved the root by counting directories up from `__file__` — sound while the
 Step 3 rather than `config.rootpath` on purpose: with no config file, pytest derives its
 rootdir from the arguments, and under `--pyargs` those are paths inside site-packages.
 
-## The make wiring this expects
+## How a consumer selects and pins the checks
 
-Selection stays exactly where the template already has it — with the bundle that owns the
-assertion, resolved at sync time — because each bundle's make fragment names its own check
-modules. No runtime manifest sniffing decides what applies, so a misconfigured repo still
-goes red instead of quietly skipping.
+Selection is still resolved by **which layers a project has**, not by sniffing its
+manifest at runtime — so a misconfigured repo goes red instead of quietly skipping a
+check. What changed at rhiza v1.4 is where that resolution lives.
 
-`core`'s `quality.mk`:
+Until v1.3 each bundle shipped a make fragment and appended to a `RHIZA_CHECKS`
+accumulator (`core`'s `quality.mk` seeded the two language-neutral checks; `python-core`,
+`rust-core`, `go-core` and `tests` each added `+=` a line). That synced make layer is
+gone — no `.rhiza/rhiza.mk`, no `.rhiza/make.d/`, no fragments. A repo generates its front
+door once:
 
-```make
-RHIZA_CHECKS ?= pytest_rhiza.checks.test_readme pytest_rhiza.checks.test_release_tags
-
-rhiza-test: install ## run the rhiza repository checks
-	@${UV_BIN} run --with 'pytest-rhiza==<version>' pytest --pyargs ${RHIZA_CHECKS}
+```bash
+uvx rhiza-task shim > Makefile
 ```
 
-`<version>` is a placeholder, not a value to copy. The sync generates the pin from the
-template release — see [Version pinning](#two-things-still-to-decide) — so the number that
-lands in a consumer's `quality.mk` is never written by hand here. It is also spelled this
-way because a literal cannot survive: nothing bumps this file (there is no
-`[[tool.bumpversion.files]]` entry for it) and nothing checks it either — a ```` ```make ````
-fence is reported by the docs check as *skipped — make fences are not checkable*, and the
-README's `bash` fences are only parsed by `bash -n`, never resolved against reality. The
-pin here read `0.1.0` for three releases for exactly that reason. `tests/test_readme_pin.py`
-is now the thing that notices.
+`make rhiza-test` still works and is still what a stranger types, but the Makefile no
+longer *contains* the recipe: a `%:` catch-all forwards unmatched targets to the pinned
+CLI, and the check list is derived from the declared layer set.
 
-`python-core`'s `python.mk` appends its own, and `rust-core` / `go-core` / `tests` do the
-same with theirs:
+Both settings live in `[tool.rhiza-task]` in the consumer's `pyproject.toml`:
 
-```make
-RHIZA_CHECKS += pytest_rhiza.checks.test_pyproject pytest_rhiza.checks.test_docstrings
+```toml
+[tool.rhiza-task]
+# Which layers this project has. Declared rather than detected, for the same reason the
+# accumulator was resolved at sync time: inference would let a misconfigured checkout
+# quietly get a different check set instead of failing.
+layers = ["python"]
+
+# The pin. One number, so the checks and the template move together rather than drifting
+# on two version axes.
+pytest-rhiza = "pytest-rhiza @ git+https://github.com/Jebel-Quant/pytest-rhiza@<version>"
 ```
 
-That is one `+=` line per bundle, replacing one synced file per bundle.
+`<version>` is a placeholder, not a value to copy — and this README deliberately writes no
+literal there. Nothing in this repository bumps a number written in `README.md` (there is
+no `[[tool.bumpversion.files]]` entry for it) and until recently nothing read it either, so
+the pin sat at `0.1.0` for three releases (#17). `tests/test_readme_pin.py` is what notices
+now.
+
+### Doctest scope is the one setting the CLI does not pass
+
+`checks/test_docstrings.py` takes its folders from the `RHIZA_DOCTEST_FOLDERS`
+environment variable, falling back to `src`. That variable is **not** set by
+`rhiza-task` — a consumer whose Python lives outside its source root exports it around
+the gate, which is what rhiza itself does:
+
+```bash +RHIZA_SKIP
+RHIZA_DOCTEST_FOLDERS="$(uvx rhiza-task print source_folder)" uvx rhiza-task rhiza-test
+```
+
+Without it the check resolves `src` alone, and a project keeping its Python elsewhere has
+its examples silently unchecked — rhiza's own repo being the extreme case, with no `src/`
+at all.
 
 ## Two things still to decide
 

--- a/src/pytest_rhiza/checks/__init__.py
+++ b/src/pytest_rhiza/checks/__init__.py
@@ -8,9 +8,14 @@ tests. So the checks are named explicitly on the command line:
     pytest --pyargs pytest_rhiza.checks.test_readme pytest_rhiza.checks.test_pyproject
 
 **One module per file the template used to sync**, names unchanged. That is deliberate:
-selection stays where it already is — with the make fragment the owning bundle ships, one
-``RHIZA_CHECKS +=`` line each — so a Python project never names the Cargo checks and
-nothing has to sniff for manifests at runtime to decide what applies.
+selection stays a property of the project's *layer set*, so a Python project never names
+the Cargo checks and nothing has to sniff for manifests at runtime to decide what applies.
+
+Where that resolution lives changed at rhiza v1.4. Up to v1.3 each bundle shipped a make
+fragment appending to a ``RHIZA_CHECKS`` accumulator; the synced make layer is gone, and
+the list is now derived from ``[tool.rhiza-task] layers`` in the consumer's
+``pyproject.toml``. The ownership model is unchanged — the column below still says which
+bundle owns each assertion.
 
 | module | bundle that names it | replaces |
 | --- | --- | --- |

--- a/src/pytest_rhiza/checks/test_docstrings.py
+++ b/src/pytest_rhiza/checks/test_docstrings.py
@@ -6,10 +6,17 @@ to ``.rhiza/tests/test_docstrings.py``. It now arrives installed, and is collect
 
 Automatically discovers all packages and runs doctests for each.
 
-**Scope.** The folders searched come from ``RHIZA_DOCTEST_FOLDERS``, which ``quality.mk``
-sets from python-core's ``DOCSTRING_FOLDERS`` accumulator — the same list ``make
-docs-coverage`` uses. With the variable unset (running pytest by hand, say) it falls back
-to ``SOURCE_FOLDER`` from ``.rhiza/.env``, defaulting to ``src``.
+**Scope.** The folders searched come from ``RHIZA_DOCTEST_FOLDERS``. Nothing sets it for
+you: ``rhiza-task`` deliberately does not export it, so a consumer whose Python lives
+outside its source root wraps the gate to pass its own ``source_folder``. With the
+variable unset — running pytest by hand, or a project whose code *is* under ``src`` — it
+falls back to ``SOURCE_FOLDER`` from ``.rhiza/.env``, then to ``src``.
+
+That ``.rhiza/.env`` rung is now a compatibility path rather than the documented home:
+rhiza retired the file at v1.4 in favour of ``[tool.rhiza-task] source-folder``. It is kept
+because a repo that has not migrated still has the file, and reading it costs nothing.
+Up to v1.3 the variable was exported by ``quality.mk`` from python-core's
+``DOCSTRING_FOLDERS`` accumulator; that make layer no longer exists.
 
 That indirection exists because this gate used to resolve ``src`` and nothing else, so a
 project keeping Python outside its source root had its docstring examples silently
@@ -40,7 +47,8 @@ from dotenv import dotenv_values
 # Read .rhiza/.env at collection time (no environment side-effects).
 RHIZA_ENV_PATH = Path(".rhiza/.env")
 
-# Set by `make rhiza-test` from DOCSTRING_FOLDERS; whitespace-separated.
+# Whitespace-separated. Exported by whatever wraps the gate — `rhiza-task` does not set
+# it, so an unset variable means "fall back", not "misconfigured".
 DOCTEST_FOLDERS_ENV = "RHIZA_DOCTEST_FOLDERS"
 
 

--- a/tests/test_readme_pin.py
+++ b/tests/test_readme_pin.py
@@ -1,11 +1,16 @@
 """The README must not pin this package to a literal version.
 
-Issue #17: `README.md` documented the make fragment consumers adopt, pinning
+Issue #17: `README.md` documented the wiring consumers adopt, pinning
 `pytest-rhiza==0.1.0` while the package was at 0.2.2 — three releases stale, and stale
 for a structural reason rather than an oversight. Nothing bumps the file (there is no
 `[[tool.bumpversion.files]]` entry for `README.md`) and nothing reads it either: the
-fragment sits in a ``` ```make ``` fence, which the docs check reports as *skipped — make
-fences are not checkable*, and the README's `bash` fences are only parsed by `bash -n`.
+example sits in a fence no checker executes, and the README's `bash` fences are only
+parsed by `bash -n`, never resolved against reality.
+
+The fence is `toml` rather than `make` since #30 rewrote that section for rhiza v1.4,
+which retired the synced make layer and moved the pin into `[tool.rhiza-task]`. The
+staleness argument is untouched by the move — a `toml` fence is no more executed than a
+`make` one was.
 
 So the fix was to stop writing a number there at all — the sync generates the pin from
 the template release, which is what the README's own "Version pinning" note says. This
@@ -23,15 +28,21 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-# `pytest-rhiza==` followed by anything digit-led: the shape a copied literal takes.
-# Normalising the separator first means `pytest_rhiza==`, `~=` and `>=` are caught too.
-_PINNED_LITERAL = re.compile(r"pytest[-_]rhiza\s*(?:==|~=|>=)\s*v?\d")
+# `pytest-rhiza` followed by a separator and anything digit-led: the shape a copied
+# literal takes. `==`, `~=` and `>=` cover the requirement forms; `@` covers the git-URL
+# form the pin uses since rhiza v1.4 moved it into `[tool.rhiza-task]`
+# (`pytest-rhiza @ git+https://…/pytest-rhiza@v0.2.1`). The underscore spelling is caught
+# too, since a copy may normalise the name either way.
+#
+# `@` deliberately does not match the two non-literal uses in that same line: `@ git+…`
+# fails `v?\d`, and so does the `@<version>` placeholder.
+_PINNED_LITERAL = re.compile(r"pytest[-_]rhiza\s*(?:==|~=|>=|@)\s*v?\d")
 
 README = Path(__file__).resolve().parents[1] / "README.md"
 
 
 def test_the_readme_pins_no_literal_version() -> None:
-    """The documented make fragment must use a placeholder, not a version number."""
+    """The documented `[tool.rhiza-task]` example must use a placeholder, not a number."""
     text = README.read_text(encoding="utf-8")
 
     offenders = [
@@ -43,7 +54,7 @@ def test_the_readme_pins_no_literal_version() -> None:
     assert not offenders, (
         "README.md pins pytest-rhiza to a literal version:\n"
         + "\n".join(offenders)
-        + "\n\nUse a placeholder such as `pytest-rhiza==<version>` instead. The sync "
+        + "\n\nUse a placeholder such as `pytest-rhiza@<version>` instead. The sync "
         "generates the real pin from the template release, and nothing in this repository "
         "bumps or checks a number written here — which is how it came to read 0.1.0 three "
         "releases after 0.1.0 (#17)."
@@ -51,15 +62,15 @@ def test_the_readme_pins_no_literal_version() -> None:
 
 
 def test_the_placeholder_is_still_there() -> None:
-    """The prohibition above passes vacuously if the fragment is deleted or renamed.
+    """The prohibition above passes vacuously if the example is deleted or renamed.
 
     Cheap, and it is the failure mode a negative assertion always has: a test that only
     says "no literal" is satisfied by a README that no longer documents the wiring at all.
     """
     text = README.read_text(encoding="utf-8")
 
-    assert "pytest-rhiza==<version>" in text, (
-        "README.md no longer shows the `pytest-rhiza==<version>` pin in the make fragment. "
-        "If the fragment moved or was rewritten, update this test to match — it is the only "
-        "thing keeping a literal version out of that file."
+    assert "pytest-rhiza@<version>" in text, (
+        "README.md no longer shows the `pytest-rhiza@<version>` placeholder in the "
+        "`[tool.rhiza-task]` example. If the example moved or was rewritten, update this "
+        "test to match — it is the only thing keeping a literal version out of that file."
     )


### PR DESCRIPTION
Closes #30.

## What was wrong

`README.md` documented the consumer integration surface as a `quality.mk` make fragment with a `RHIZA_CHECKS` accumulator, plus a `rhiza-test:` recipe. Verified against a shallow clone of `jebel-quant/rhiza@v1.4.2`: **the synced make layer is gone.** `core` ships no `Makefile` and no `.rhiza/rhiza.mk`, `.rhiza/make.d/` no longer exists in any bundle, and `find -name '*.mk'` over the tag returns nothing — all sixteen fragments retired.

## Correction to the issue as filed

The issue speculated that `RHIZA_CHECKS` and `make rhiza-test` were retired outright. **They are not**, and upstream's `CLAUDE.md` is explicit:

> Ownership still lives with the bundle, as a `RHIZA_CHECKS` accumulator. […] *(Historical: the accumulator is a derivation from the layer set in rhiza-task now.)*

So the ownership model is unchanged; only its home moved. This PR rewrites the section around **where the resolution lives** rather than asserting the mechanism disappeared:

| | v1.3 | v1.4.2 |
| --- | --- | --- |
| check selection | `RHIZA_CHECKS ?=` / `+=` across bundle `*.mk` | derived from `[tool.rhiza-task] layers` |
| the pin | `RHIZA_CHECKS_VERSION ?= 0.2.1` in `quality.mk` | `[tool.rhiza-task] pytest-rhiza` |
| front door | synced `Makefile` + `rhiza.mk` + 16 fragments | `uvx rhiza-task shim > Makefile`, `%:` catch-all |

`make rhiza-test` still works and is still what a stranger types.

## The doctest-scope find

Worth calling out because it cuts the other way — **our code was never stale, only the prose.** `checks/test_docstrings.py` reads `RHIZA_DOCTEST_FOLDERS`, and that is still the live interface upstream. What changed is the setter: `quality.mk` exporting python-core's `DOCSTRING_FOLDERS` became `RHIZA_DOCTEST_FOLDERS="$(uvx rhiza-task print source_folder)"`, wrapped around the gate by each repo. The CLI deliberately does not set it (`tests/utils/test_gate_scope.py:22` upstream), so this is a consumer obligation and the README now documents it — without it the check resolves `src` alone and a project keeping Python elsewhere has its examples silently unchecked.

The `.rhiza/.env` rung in that module is relabelled a compatibility path: rhiza retired the file at v1.4 (#1555 upstream) for `[tool.rhiza-task] source-folder`. The fallback stays — an unmigrated repo still has the file, and reading it costs nothing.

## Files

- `README.md` — "The make wiring this expects" → "How a consumer selects and pins the checks", plus a subsection on doctest scope
- `src/pytest_rhiza/checks/__init__.py` — the `RHIZA_CHECKS +=` framing
- `src/pytest_rhiza/checks/test_docstrings.py` — module docstring and the `DOCTEST_FOLDERS_ENV` comment
- `tests/test_readme_pin.py` — moves with the fence it guards

## The pin test

`test_the_placeholder_is_still_there` intentionally fails when that fence is rewritten, so it had to move in the same commit. Two changes:

- the prohibition gains `@`, so the git-URL form of a literal (`pytest-rhiza@v0.2.1`) is caught alongside `==`/`~=`/`>=`
- the placeholder assertion looks for `pytest-rhiza@<version>`

Verified the `@` branch does not false-positive on the two non-literal uses in that same README line: `pytest-rhiza @ git+…` and `pytest-rhiza@<version>` both fail the trailing `v?\d`.

## Verification

- `make test` — 111 passed, coverage 98.95%
- `uv run pytest --pyargs pytest_rhiza.checks.test_readme pytest_rhiza.checks.test_readme_validation` — 5 passed, i.e. the rewritten fences pass our own README checks
- `make lint` — 8/8 hooks

## Not in scope

The "Two things still to decide" section still claims version pinning is open. That is #36, which rewrites it — this PR only drops the now-dangling cross-reference into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)