### PR TITLE
docs: make the public surface documented by example, not just described

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,29 @@ explicitly with `--pyargs`. One module per file the template used to sync, names
 | `test_cargo_toml` | `rust-core` | `.rhiza/tests/test_cargo_toml.py` |
 | `test_go_module` | `go-core` | `.rhiza/tests/test_go_module.py` |
 
+That table is not prose. The fence below enumerates what the installed package actually
+ships, and `make rhiza-test` executes it against this README — so adding or removing a
+check without updating the list above turns this block red:
+
+```python
+import pkgutil
+
+import pytest_rhiza.checks as checks
+
+for module in sorted(m.name for m in pkgutil.iter_modules(checks.__path__)):
+    print(module)
+```
+
+```result
+test_cargo_toml
+test_docstrings
+test_go_module
+test_pyproject
+test_readme
+test_readme_validation
+test_release_tags
+```
+
 ### Which repository is "root"
 
 The one deliberate behaviour change from the synced suite. `.rhiza/tests/conftest.py`

--- a/src/pytest_rhiza/_bumpversion.py
+++ b/src/pytest_rhiza/_bumpversion.py
@@ -69,6 +69,35 @@ def has_bumpversion_section(path: Path) -> bool:
         True when the file declares ``[tool.bumpversion]`` (TOML) or ``[bumpversion]``
         (INI). ``.bumpversion.toml`` nests the table under ``[tool]`` just as
         pyproject.toml does.
+
+    Examples:
+        >>> import tempfile
+        >>> root = Path(tempfile.mkdtemp())
+        >>> _ = (root / "pyproject.toml").write_text("[tool.bumpversion]")
+        >>> has_bumpversion_section(root / "pyproject.toml")
+        True
+
+        A file that exists but declares no section is False, not an error:
+
+        >>> _ = (root / "setup.cfg").write_text("[metadata]")
+        >>> has_bumpversion_section(root / "setup.cfg")
+        False
+
+        So is a file that is not there at all — the caller asks about candidates:
+
+        >>> has_bumpversion_section(root / ".bumpversion.toml")
+        False
+
+        And so is malformed TOML. "We could not read a section out of this" is the same
+        answer as "there is none", and the config gate reports the absence rather than
+        raising here:
+
+        >>> _ = (root / ".bumpversion.toml").write_text("[tool.bumpversion")
+        >>> has_bumpversion_section(root / ".bumpversion.toml")
+        False
+
+        Note the ``.cfg`` case above takes the containment branch, not the TOML parser —
+        an INI file is never handed to ``tomllib``.
     """
     if not path.is_file():
         return False
@@ -90,6 +119,23 @@ def discovered_configs(root: Path) -> list[str]:
 
     Returns:
         The matching names from :data:`DISCOVERABLE_CONFIGS`, in search order.
+
+    Examples:
+        >>> import tempfile
+        >>> root = Path(tempfile.mkdtemp())
+        >>> discovered_configs(root)
+        []
+
+        Search order, not filesystem order — ``.bumpversion.toml`` is what
+        bump-my-version reads first, so it leads the list however it was written:
+
+        >>> _ = (root / "pyproject.toml").write_text("[tool.bumpversion]")
+        >>> _ = (root / ".bumpversion.toml").write_text("[tool.bumpversion]")
+        >>> discovered_configs(root)
+        ['.bumpversion.toml', 'pyproject.toml']
+
+        Two entries is the finding, not the goal: the second is a version location
+        nobody maintains. :func:`shadowing_configs` is what names it.
     """
     return [name for name in DISCOVERABLE_CONFIGS if has_bumpversion_section(root / name)]
 
@@ -105,6 +151,26 @@ def shadowing_configs(root: Path, winner: str) -> list[str]:
         Every other discoverable config that also declares a section. Whether those
         shadow the winner or are shadowed *by* it depends on search order — either way
         the second config is a version location nobody is maintaining.
+
+    Examples:
+        >>> import tempfile
+        >>> root = Path(tempfile.mkdtemp())
+        >>> _ = (root / ".bumpversion.toml").write_text("[tool.bumpversion]")
+        >>> shadowing_configs(root, ".bumpversion.toml")
+        []
+
+        A second section anywhere discoverable is reported, whichever way round the
+        search order puts them:
+
+        >>> _ = (root / "pyproject.toml").write_text("[tool.bumpversion]")
+        >>> shadowing_configs(root, ".bumpversion.toml")
+        ['pyproject.toml']
+
+        The winner need not exist for the question to be worth asking — a repo with only
+        the *wrong* config is exactly the case the gate is for:
+
+        >>> shadowing_configs(root, "setup.cfg")
+        ['.bumpversion.toml', 'pyproject.toml']
     """
     return [name for name in DISCOVERABLE_CONFIGS if name != winner and has_bumpversion_section(root / name)]
 
@@ -118,6 +184,20 @@ def legacy_config_hint(root: Path) -> str:
     Returns:
         The hint, with a leading space so it appends to a message, or ``""`` when the
         leftover file is absent.
+
+    Examples:
+        >>> import tempfile
+        >>> root = Path(tempfile.mkdtemp())
+        >>> legacy_config_hint(root)
+        ''
+
+        Present, and the caller gets a sentence it can concatenate — note the leading
+        space, which is why this returns text rather than a bool:
+
+        >>> _ = (root / ".rhiza").mkdir()
+        >>> _ = (root / ".rhiza" / ".cfg.toml").write_text("[tool.bumpversion]")
+        >>> legacy_config_hint(root).startswith(" A leftover")
+        True
     """
     if not (root / LEGACY_CONFIG).is_file():
         return ""

--- a/src/pytest_rhiza/checks/test_docstrings.py
+++ b/src/pytest_rhiza/checks/test_docstrings.py
@@ -127,6 +127,52 @@ def _doctest_folders(root: Path, values: dict) -> list[Path]:
 
     Returns:
         Each configured folder that exists, in order, without duplicates.
+
+    Examples:
+        The precedence is the whole point of this function, so it is worth one runnable
+        example per rung. The environment is saved and restored because these lines
+        execute in whatever process is running the doctests.
+
+        >>> import os, tempfile
+        >>> root = Path(tempfile.mkdtemp())
+        >>> _ = (root / "src").mkdir()
+        >>> _ = (root / "utils").mkdir()
+        >>> saved = os.environ.pop(DOCTEST_FOLDERS_ENV, None)
+
+        The variable wins, is whitespace-separated, and silently drops what does not
+        exist — a configured folder a project has since renamed is not an error:
+
+        >>> os.environ[DOCTEST_FOLDERS_ENV] = "src utils nope"
+        >>> [p.name for p in _doctest_folders(root, {})]
+        ['src', 'utils']
+
+        Unset, it falls back to ``SOURCE_FOLDER`` from ``.rhiza/.env``:
+
+        >>> del os.environ[DOCTEST_FOLDERS_ENV]
+        >>> [p.name for p in _doctest_folders(root, {"SOURCE_FOLDER": "utils"})]
+        ['utils']
+
+        …and to ``src`` when that is absent too:
+
+        >>> [p.name for p in _doctest_folders(root, {})]
+        ['src']
+
+        Duplicates collapse, so a folder named twice is walked once:
+
+        >>> os.environ[DOCTEST_FOLDERS_ENV] = "src src"
+        >>> [p.name for p in _doctest_folders(root, {})]
+        ['src']
+
+        Nothing configured that exists yields an empty list, which is what makes
+        :func:`test_doctests` skip rather than pass vacuously:
+
+        >>> os.environ[DOCTEST_FOLDERS_ENV] = "nope"
+        >>> _doctest_folders(root, {})
+        []
+
+        >>> _ = os.environ.pop(DOCTEST_FOLDERS_ENV, None)
+        >>> if saved is not None:
+        ...     os.environ[DOCTEST_FOLDERS_ENV] = saved
     """
     configured = os.environ.get(DOCTEST_FOLDERS_ENV, "").split()
     if not configured:

--- a/src/pytest_rhiza/plugin.py
+++ b/src/pytest_rhiza/plugin.py
@@ -45,6 +45,61 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
+def _resolve_root(
+    override: str | None,
+    inipath: pathlib.Path | None,
+    invocation_dir: pathlib.Path,
+) -> pathlib.Path:
+    """Pick the repository root from the three things that can name it.
+
+    Split out of the :func:`root` fixture so the resolution order is documented by
+    something that runs. A fixture needs a live pytest session to exercise, which is why
+    this ladder went undocumented-by-example for so long.
+
+    Args:
+        override: The ``--rhiza-root`` value, or None.
+        inipath: Path to the config file pytest found, or None when there is none.
+        invocation_dir: The directory pytest was invoked from.
+
+    Returns:
+        The repository root.
+
+    Examples:
+        These read results back through ``.as_posix()`` and ``.name`` rather than
+        repr'ing the ``Path``. ``repr`` would print ``PosixPath`` here and
+        ``WindowsPath`` on the Windows leg of the matrix, so a doctest asserting it
+        would measure the platform instead of the ladder.
+
+        ``--rhiza-root`` wins outright, over both of the other two:
+
+        >>> _resolve_root("/repo", pathlib.Path("/ini/pytest.ini"), pathlib.Path("/cwd")).name
+        'repo'
+
+        With no override, the directory holding the config file:
+
+        >>> _resolve_root(None, pathlib.Path("/repo/pytest.ini"), pathlib.Path("/cwd")).as_posix()
+        '/repo'
+
+        With neither, the invocation directory — *not* ``rootpath``, which under
+        ``--pyargs`` can point into site-packages:
+
+        >>> _resolve_root(None, None, pathlib.Path("/repo")).as_posix()
+        '/repo'
+
+        An empty ``--rhiza-root`` is treated as absent rather than as the current
+        directory, so a shell expanding an unset variable falls through to the ladder
+        instead of silently checking the wrong tree:
+
+        >>> _resolve_root("", pathlib.Path("/repo/pytest.ini"), pathlib.Path("/cwd")).as_posix()
+        '/repo'
+    """
+    if override:
+        return pathlib.Path(override).absolute()
+    if inipath is not None:
+        return inipath.parent
+    return pathlib.Path(invocation_dir)
+
+
 @pytest.fixture(scope="session")
 def root(pytestconfig: pytest.Config) -> pathlib.Path:
     """Return the repository under test as a :class:`pathlib.Path`.
@@ -61,18 +116,19 @@ def root(pytestconfig: pytest.Config) -> pathlib.Path:
     rather than at the project. The invocation directory cannot: ``make rhiza-test``
     runs at the repository root.
 
+    The ladder itself lives in :func:`_resolve_root`, where it is doctested.
+
     Args:
         pytestconfig: The session's pytest config.
 
     Returns:
         The repository root.
     """
-    override = pytestconfig.getoption("rhiza_root")
-    if override:
-        return pathlib.Path(override).absolute()
-    if pytestconfig.inipath is not None:
-        return pytestconfig.inipath.parent
-    return pathlib.Path(pytestconfig.invocation_params.dir)
+    return _resolve_root(
+        pytestconfig.getoption("rhiza_root"),
+        pytestconfig.inipath,
+        pathlib.Path(pytestconfig.invocation_params.dir),
+    )
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Closes #31.

## Before / after

| | before | after |
| --- | --- | --- |
| doctest examples | 2 | 50 |
| files carrying any | 1 of 12 | 4 of 12 |
| on the public surface | none | `plugin.py`, `checks/test_docstrings.py` |
| README `python` fences | 0 | 1, executed and diffed |

All 50 execute and pass (`check_doc_examples.py --source-root src --run`, in the project's own environment: `attempted: 50, failed: 0, unimportable: []`).

## `plugin.py` — a small refactor to make the ladder testable

The `root` fixture's three-rung resolution order is the most consequential behaviour in the package, and it was documented in prose only. A fixture can't be doctested — it needs a live pytest session, which is precisely why this went un-exampled.

So the ladder moved into a pure `_resolve_root(override, inipath, invocation_dir)` and the fixture became a call to it. The examples cover all three rungs plus the empty-`--rhiza-root` case, where a shell expanding an unset variable has to fall through instead of silently resolving the current directory.

**Cross-platform detail worth flagging in review:** the examples read results back through `.as_posix()` and `.name` rather than repr'ing the `Path`. `repr` prints `PosixPath` locally and `WindowsPath` on the Windows leg of the matrix, so a doctest asserting it would measure the platform instead of the ladder. Same class of trap as the `newline="\n"` in `Subject.write`.

## `_bumpversion.py` — four helpers

These now show what the prose asserted but never demonstrated: that **search order** rather than filesystem order decides the list, that a shadowing config is reported whichever way round the pair sits, and that absent / present-but-empty / malformed all answer `False` rather than raising.

Writing them caught a bug in my own first draft: the malformed-TOML example wrote to `.bumpversion.cfg`, which takes the `"[bumpversion]" in text` containment branch and never reaches `tomllib` — so it returned `False` for the wrong reason and proved nothing about TOML handling. Retargeted at `.bumpversion.toml`, with the `.cfg` branch now called out explicitly. Exactly the kind of thing this issue exists to surface.

## `checks/test_docstrings.py` — the scope precedence

One example per rung of `RHIZA_DOCTEST_FOLDERS` → `SOURCE_FOLDER` → `src`, plus the empty result that makes the gate *skip* rather than pass vacuously. The block saves and restores the environment, since these lines execute in whatever process is running the doctests.

## `README.md` — the first executable fence

```python
import pkgutil

import pytest_rhiza.checks as checks

for module in sorted(m.name for m in pkgutil.iter_modules(checks.__path__)):
    print(module)
```

…diffed against a `result` block listing the seven modules. Two things this buys:

1. The check-module table above it can no longer drift from what the package ships — add or remove a check without updating the table and the fence goes red.
2. It exercises our own `test_readme_validation` against our own README. Nothing did before, which meant the mechanism this package *ships* was never dogfooded on the one README we control.

## Note on D301

None of the new examples use `\n` escapes. Ruff's D301 requires `r"""` wherever a docstring carries a backslash, and single-line TOML (`"[tool.bumpversion]"`) makes the escape unnecessary rather than merely permitted.

## Verification

- `make test` — 111 passed, coverage 98.95% (`plugin.py` stays at 100% across the refactor)
- `uv run pytest --pyargs …test_readme …test_readme_validation …test_docstrings` — 6 passed, i.e. self-applied
- `make lint` — 8/8 hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)