### PR TITLE
build: give typecheck, docs-coverage and security local entry points

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 
 PREK := uvx prek
 
-.PHONY: help lint install-hooks test clean
+.PHONY: help lint install-hooks typecheck docs-coverage security test clean
 
 help: ## Show this help
 	@grep -hE '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) \
@@ -18,6 +18,32 @@ lint: ## Run all pre-commit hooks over every file
 
 install-hooks: ## Install the git pre-commit hook
 	$(PREK) install
+
+# The three gates below run in CI through the reusable workflow
+# `jebel-quant/rhiza/.github/workflows/rhiza_ci.yml`, which means their flags are owned
+# upstream rather than by this repo. They had no local entry point at all, so a
+# contributor could not reproduce a red CI job before pushing — the same hazard the
+# comment on `test` names, one gate over.
+#
+# Each recipe is the CI job's command line copied verbatim, and that is the point: the
+# thresholds are not re-decided here. Read them off a run with
+# `gh run view <id> --log | grep -E '^\$'` if they ever need re-checking, and keep the
+# two in step.
+#
+# Deliberately *not* mirrored into `[tool.interrogate]` / `[tool.mypy]` in pyproject.toml.
+# A committed table would be a second home for a threshold whose first home is upstream's
+# workflow, and two homes for one number is how they drift apart.
+
+typecheck: ## Type-check src (mirrors the rhiza_ci "Type checking" job)
+	uv run --with ty ty check src
+
+docs-coverage: ## Docstring coverage (mirrors the rhiza_ci "docs-coverage" job)
+	uv run --with interrogate interrogate -vv --fail-under 100 --ignore-init-method --ignore-magic src tests
+
+# bandit only, matching the CI job. The dependency half of `security` is pip-audit, which
+# this repo runs in its own ci.yml `audit` job rather than here.
+security: ## Bandit scan of src (mirrors the rhiza_ci "Security scanning" job)
+	uvx bandit -r src -ll -q
 
 # Same flags CI runs, deliberately: a coverage threshold that only exists in one of the
 # two is a threshold nobody notices crossing. `--cov=src` matches what `rhiza-task test`

--- a/README.md
+++ b/README.md
@@ -129,6 +129,22 @@ uv sync
 uv run pytest
 ```
 
+`make help` lists the gates. Every one of them is what CI runs, so a green local sweep
+means a green pipeline:
+
+| target | what it runs |
+| --- | --- |
+| `make lint` | all pre-commit hooks, via prek |
+| `make typecheck` | `ty check src` |
+| `make docs-coverage` | interrogate over `src` and `tests`, at a 100% floor |
+| `make security` | bandit over `src` |
+| `make test` | the suite, with the 90% coverage gate |
+
+`typecheck`, `docs-coverage` and `security` take their flags from the reusable workflow
+`jebel-quant/rhiza/.github/workflows/rhiza_ci.yml`, so the recipes mirror those jobs
+rather than setting a threshold of their own — see the comment above them in the
+`Makefile`.
+
 The checks run against this repository too — it is a Python project with a README, a
 `pyproject.toml` and a release config, so it is a valid subject for its own assertions:
 


### PR DESCRIPTION
Closes #32.

## The gap

Three gates ran in CI with no local entry point, so a contributor could not reproduce a red pipeline before pushing. `Makefile` already names this hazard for coverage:

> Same flags CI runs, deliberately: a coverage threshold that only exists in one of the two is a threshold nobody notices crossing.

The same argument applies to a type error and a 100% docstring floor.

## Where the flags came from

These jobs live in the reusable workflow `jebel-quant/rhiza/.github/workflows/rhiza_ci.yml`, so their flags are **owned upstream**. Rather than invent thresholds, each recipe is the job's command line copied verbatim, read off run `32386168029`:

| target | command |
| --- | --- |
| `typecheck` | `uv run --with ty ty check src` |
| `docs-coverage` | `uv run --with interrogate interrogate -vv --fail-under 100 --ignore-init-method --ignore-magic src tests` |
| `security` | `uvx bandit -r src -ll -q` |

Worth noting what that surfaced: docs-coverage runs at **`--fail-under 100`** over `src` *and* `tests`, which is a stricter bar than my scorecard assumed when it marked this subcategory 8 on CI-log evidence alone.

## On `[tool.interrogate]` / `[tool.mypy]`

The issue offered a committed config table as an option. **Declined, deliberately.** The first home for these thresholds is upstream's workflow; a table here would be a second home for the same number, and two homes is how they drift. The `Makefile` comment says where to re-read them instead:

```
gh run view <id> --log | grep -E '^\$'
```

A consequence to be aware of: bare `uvx mypy` / `uvx interrogate` still have no config to read, so tooling that looks for one (including `/rhiza:quality`'s fallback ladder) will still report these as unconfigured. That is accurate — the repo genuinely does not own these thresholds.

## `security` scope

Bandit only, matching the CI job. The dependency half is pip-audit, which this repo already runs in its own `ci.yml` `audit` job — adding it here would double-count one result.

## Verification

Each target run bare on this branch:

- `make typecheck` → `All checks passed!`
- `make docs-coverage` → `RESULT: PASSED (minimum: 100.0%, actual: 100.0%)`, 271/271 objects
- `make security` → exit 0, no findings (it prints pre-existing `nosec encountered` and comment-parse warnings; identical output to the CI job)
- `make test` → 111 passed, 98.95%
- `make lint` → 8/8 hooks
- `make help` lists all five

## Also

README's Development section now tabulates the five gates and says why the three new recipes mirror CI rather than configuring anything, so `make help` is not the only way to discover them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)