### PR TITLE
ci: self-apply the tag-dependent checks, and fail if they skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,56 @@ jobs:
       # dependency propagates into every consumer's test environment.
       - name: Audit dependencies
         run: uvx pip-audit
+
+  self-check:
+    name: Rhiza checks, self-applied (with tags)
+    runs-on: ubuntu-latest
+
+    # Why this job exists, when `(RHIZA) CI` already has a "Rhiza repository checks" job:
+    # that job is green while two of its assertions never run. Its log reads
+    #
+    #     SKIPPED [1] .../checks/test_release_tags.py:25: No version tags found in repository
+    #     SKIPPED [1] .../checks/test_pyproject.py:334: No version tags found in repository
+    #     32 passed, 2 skipped
+    #
+    # This repository has tags — v0.2.0, v0.2.1, v0.2.2 — so those are not honest skips.
+    # The reusable workflow's `actions/checkout` fetches none, `latest_tag` finds none, and
+    # the two assertions that compare [project].version against the newest vX.Y.Z skip. A
+    # gate that skips is not a gate, and a green job reporting coverage it does not have is
+    # worse than a red one (#34).
+    #
+    # The real fix is `fetch-tags`/`fetch-depth: 0` in
+    # jebel-quant/rhiza/.github/workflows/rhiza_ci.yml, which is upstream and not editable
+    # here. This job is the local counterpart: it runs the same two modules against this
+    # repository with the history they need. Delete it once upstream fetches tags.
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The entire point. `fetch-tags` alone is not enough on a shallow clone — the
+          # tagged commits have to be present for `git rev-parse <tag>^{commit}` and
+          # `git branch --contains` to answer, and test_release_tags skips on both.
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+
+      # `-rs` prints skip reasons, which is what the guard below reads. Only these two
+      # modules: they are the tag-dependent ones, and locally with tags present they are
+      # 28 passed / 0 skipped, so "no skips" is a bar this repo actually meets rather than
+      # an aspiration.
+      #
+      # The guard matters as much as the checkout. Fetching tags fixes the symptom today;
+      # asserting that nothing skipped is what stops the silent-skip failure mode coming
+      # back through some other change, which is the actual defect in #34.
+      - name: Run the tag-dependent checks against this repository
+        run: |
+          set -o pipefail
+          uv run --group test pytest -q -rs --pyargs \
+            pytest_rhiza.checks.test_release_tags \
+            pytest_rhiza.checks.test_pyproject | tee checks.log
+          if grep -q "skipped" checks.log; then
+            echo "::error::A tag-dependent check skipped. A skipped assertion reads as a pass, which is the defect this job exists to prevent (#34)."
+            exit 1
+          fi


### PR DESCRIPTION
Closes #34.

## The defect

`(RHIZA) CI` → "Rhiza repository checks" is **green while two of its assertions never run**:

```
SKIPPED [1] .../checks/test_release_tags.py:25: No version tags found in repository
SKIPPED [1] .../checks/test_pyproject.py:334: No version tags found in repository
32 passed, 2 skipped
```

This repository has `v0.2.0`, `v0.2.1`, `v0.2.2`. Those are not honest skips — the reusable workflow's `actions/checkout` fetches no tags, so the `latest_tag` fixture finds none and the two assertions that compare `[project].version` against the newest `vX.Y.Z` skip out.

A gate that skips is not a gate, and this is the failure mode a scorecard is least able to catch: the job is green, the count looks healthy, and the assertion that would have caught a botched release is the one not running.

## Where the real fix belongs

**Upstream.** The checkout step is in `jebel-quant/rhiza/.github/workflows/rhiza_ci.yml` and wants `fetch-tags: true` / `fetch-depth: 0`. Not editable from here.

This PR adds the local counterpart: a `self-check` job in this repo's own `ci.yml` that runs the same two modules with the history they need. The job comment says to delete it once upstream fetches tags.

## Two deliberate choices

**`fetch-depth: 0`, not `fetch-tags: true`.** Tag *names* alone are not enough. `test_release_tags` runs `git rev-parse <tag>^{commit}` and `git branch --contains`, and skips on either failing — so the tagged commits have to actually be present, not just their refs.

**The guard is the point, not the checkout.** Fetching tags fixes today's symptom. Asserting that nothing skipped is what stops the silent-skip mode returning through some later change:

```bash
if grep -q "skipped" checks.log; then
  echo "::error::A tag-dependent check skipped. A skipped assertion reads as a pass…"
  exit 1
fi
```

Without it this PR would fix one instance of a class of bug.

## Verification

Both directions tested locally, since a guard that never fires is worthless:

| case | result |
| --- | --- |
| this repo, tags present | `28 passed in 0.05s`, guard quiet, exit 0 |
| tagless throwaway repo | guard fires on exactly `No version tags found in repository`, exit 1 |

Also:
- `actionlint .github/workflows/ci.yml` → exit 0
- YAML parses; jobs are now `lint, test, audit, self-check`
- `make lint` — 8/8 hooks

## Scope

Only the two tag-dependent modules. "No skips" is a bar this repo demonstrably meets for them (28/0 locally) rather than an aspiration — asserting it across the whole check set would be a different and less defensible claim, since some skips elsewhere are legitimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)