### PR TITLE
refactor: move the bash-fence exclusion rules into _fences

### DIFF
--- a/src/pytest_rhiza/_fences.py
+++ b/src/pytest_rhiza/_fences.py
@@ -64,6 +64,102 @@ def should_skip(flags: str) -> bool:
     return SKIP_FLAG in flags
 
 
+def _holds_a_command(code: str) -> bool:
+    r"""Report whether a fence holds anything besides blank lines and comments.
+
+    Args:
+        code: The fence body.
+
+    Returns:
+        True when at least one non-comment, non-blank line is present.
+
+    Examples:
+        >>> _holds_a_command("make test\n")
+        True
+        >>> _holds_a_command("# just explaining\n#\n\n")
+        False
+        >>> _holds_a_command("")
+        False
+
+        An inline comment does not make the line a comment:
+
+        >>> _holds_a_command("make test  # runs the suite")
+        True
+    """
+    lines = [line.strip() for line in code.split("\n") if line.strip()]
+    return any(not line.startswith("#") for line in lines)
+
+
+def skip_reason(flags: str, code: str) -> str | None:
+    r"""Return why a bash fence needs no parsing, or None when it should be parsed.
+
+    The three exclusions are each here for a different reason, which is why this returns
+    the reason rather than a bool: the caller logs it, and "skipped 4 of 6 fences" with
+    no explanation is the kind of green that hides a mistake.
+
+    Args:
+        flags: Text following the language identifier on the opening fence line.
+        code: The fence body.
+
+    Returns:
+        A short phrase naming the exclusion, or None to parse the fence.
+
+    Examples:
+        >>> skip_reason("", "make test") is None
+        True
+        >>> skip_reason(" +RHIZA_SKIP", "make test")
+        '+RHIZA_SKIP flag'
+
+        A directory tree is prose drawn with box characters, not shell:
+
+        >>> skip_reason("", "src/\n\u251c\u2500\u2500 pytest_rhiza/")
+        'directory tree representation'
+
+        A comment-only fence has nothing to parse and no way to be wrong:
+
+        >>> skip_reason("", "# see the Makefile")
+        'only comments'
+
+        Order matters where a fence qualifies twice — the flag is the author's explicit
+        instruction, so it is reported ahead of anything inferred:
+
+        >>> skip_reason(" +RHIZA_SKIP", "# see the Makefile")
+        '+RHIZA_SKIP flag'
+    """
+    if should_skip(flags):
+        return f"{SKIP_FLAG} flag"
+    if any(marker in code for marker in TREE_MARKERS):
+        return "directory tree representation"
+    if not _holds_a_command(code):
+        return "only comments"
+    return None
+
+
+def classify_bash_blocks(content: str) -> list[tuple[int, str, str | None]]:
+    r"""Return every bash fence in a markdown document, with its exclusion verdict.
+
+    Args:
+        content: The markdown source.
+
+    Returns:
+        One ``(index, code, skip_reason)`` triple per fence, in document order. The index
+        is the fence's position among *all* bash fences, so a failure message names the
+        same block a reader counting fences would.
+
+    Examples:
+        >>> doc = "```bash\nmake test\n```\n\n```bash +RHIZA_SKIP\nrm -rf /\n```\n"
+        >>> [(i, reason) for i, _code, reason in classify_bash_blocks(doc)]
+        [(0, None), (1, '+RHIZA_SKIP flag')]
+
+        A document with no bash fences is empty rather than an error — a Rust project's
+        README may legitimately have none:
+
+        >>> classify_bash_blocks("# Title\n")
+        []
+    """
+    return [(index, code, skip_reason(flags, code)) for index, (flags, code) in enumerate(BASH_BLOCK.findall(content))]
+
+
 @functools.cache
 def bash_usable() -> bool:
     r"""Return True when ``bash -n`` actually parses a trivially valid snippet.

--- a/src/pytest_rhiza/checks/test_readme.py
+++ b/src/pytest_rhiza/checks/test_readme.py
@@ -27,7 +27,31 @@ from pathlib import Path
 
 import pytest
 
-from pytest_rhiza._fences import BASH, BASH_BLOCK, SKIP_FLAG, TREE_MARKERS, bash_usable, should_skip
+from pytest_rhiza._fences import BASH, bash_usable, classify_bash_blocks
+
+
+def _assert_parses(index: int, code: str) -> None:
+    """Fail the test unless ``bash -n`` accepts one fence.
+
+    Args:
+        index: The fence's position among all bash fences, for the failure message.
+        code: The fence body.
+
+    Raises:
+        Failed: via :func:`pytest.fail`, when bash rejects the snippet.
+    """
+    result = subprocess.run(  # nosec B603 B607 - `bash -n` parses without executing
+        [BASH, "-n"],
+        input=code,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return
+    # stdout as well as stderr: a bash that fails for a reason other than syntax tends to
+    # explain itself on stdout, and a blank error is the least actionable failure there is.
+    detail = (result.stderr + result.stdout).strip() or f"exited {result.returncode}, saying nothing"
+    pytest.fail(f"Bash block {index} has syntax errors:\nCode:\n{code}\nError:\n{detail}")
 
 
 class TestReadmeExists:
@@ -59,42 +83,20 @@ class TestReadmeBashFragments:
         Skips where no working bash exists — see :func:`pytest_rhiza._fences.bash_usable`.
         A README's fences are the same text on every platform, so one runner that can
         parse them is enough; a runner that cannot must not invent syntax errors.
+
+        Which fences are excluded, and why, is
+        :func:`pytest_rhiza._fences.classify_bash_blocks` — doctested there rather than
+        settled inline here.
         """
         if not bash_usable():
             pytest.skip("no working `bash -n` on this platform; README fences unchecked")
 
-        content = (root / "README.md").read_text(encoding="utf-8")
-        bash_blocks = BASH_BLOCK.findall(content)
+        blocks = classify_bash_blocks((root / "README.md").read_text(encoding="utf-8"))
+        logger.info("Found %d bash code block(s) in README", len(blocks))
 
-        logger.info("Found %d bash code block(s) in README", len(bash_blocks))
-
-        for i, (flags, code) in enumerate(bash_blocks):
-            if should_skip(flags):
-                logger.info("Skipping bash block %d (%s flag)", i, SKIP_FLAG)
+        for index, code, reason in blocks:
+            if reason is not None:
+                logger.info("Skipping bash block %d (%s)", index, reason)
                 continue
-
-            if any(marker in code for marker in TREE_MARKERS):
-                logger.info("Skipping bash block %d (directory tree representation)", i)
-                continue
-
-            # A block that is only comments has nothing to parse and no way to be wrong.
-            lines = [line.strip() for line in code.split("\n") if line.strip()]
-            if not [line for line in lines if not line.startswith("#")]:
-                logger.info("Skipping bash block %d (only comments)", i)
-                continue
-
-            logger.debug("Checking bash block %d:\n%s", i, code)
-
-            result = subprocess.run(  # nosec B603 B607 - `bash -n` parses without executing
-                [BASH, "-n"],
-                input=code,
-                capture_output=True,
-                text=True,
-            )
-
-            if result.returncode != 0:
-                # stdout as well as stderr: a bash that fails for a reason other than
-                # syntax tends to explain itself on stdout, and a blank error is the
-                # least actionable failure there is.
-                detail = (result.stderr + result.stdout).strip() or f"exited {result.returncode}, saying nothing"
-                pytest.fail(f"Bash block {i} has syntax errors:\nCode:\n{code}\nError:\n{detail}")
+            logger.debug("Checking bash block %d:\n%s", index, code)
+            _assert_parses(index, code)

--- a/tests/test_fences.py
+++ b/tests/test_fences.py
@@ -12,7 +12,89 @@ import subprocess
 from pathlib import Path
 
 from pytest_rhiza import _fences
-from pytest_rhiza._fences import BASH_BLOCK, CODE_BLOCK, bash_usable, should_skip
+from pytest_rhiza._fences import BASH_BLOCK, CODE_BLOCK, bash_usable, classify_bash_blocks, should_skip, skip_reason
+
+
+class TestSkipReason:
+    """Tests for the exclusion verdict that decides which bash fences are parsed.
+
+    Extracted from ``checks/test_readme.py`` in #35, where the three exclusions were
+    inline ``continue`` branches inside the test and so could only be exercised end to
+    end, through a subject repository and a README. They are a pure function of
+    ``(flags, code)`` now, so the edges get direct tests.
+    """
+
+    def test_a_plain_command_fence_is_parsed(self) -> None:
+        """No exclusion applies, so the fence goes to `bash -n`."""
+        assert skip_reason("", "make test") is None
+
+    def test_the_skip_flag_excludes(self) -> None:
+        """The author's explicit opt-out is honoured and named."""
+        assert skip_reason(" +RHIZA_SKIP", "make test") == "+RHIZA_SKIP flag"
+
+    def test_a_directory_tree_is_excluded(self) -> None:
+        """Box-drawing characters mean the fence is prose, not shell."""
+        assert skip_reason("", "src/\n├── pytest_rhiza/") == "directory tree representation"
+        assert skip_reason("", "a\n└── b") == "directory tree representation"
+        assert skip_reason("", "a\n│ b") == "directory tree representation"
+
+    def test_a_comment_only_fence_is_excluded(self) -> None:
+        """Nothing to parse, and no way for it to be wrong."""
+        assert skip_reason("", "# see the Makefile") == "only comments"
+        assert skip_reason("", "# one\n# two\n\n") == "only comments"
+
+    def test_an_empty_fence_is_excluded(self) -> None:
+        """An empty body holds no command, so it is the comment-only case."""
+        assert skip_reason("", "") == "only comments"
+        assert skip_reason("", "\n  \n") == "only comments"
+
+    def test_an_inline_comment_does_not_exclude(self) -> None:
+        """A trailing comment leaves a command on the line, which must still parse."""
+        assert skip_reason("", "make test  # runs the suite") is None
+
+    def test_a_command_after_a_comment_does_not_exclude(self) -> None:
+        """One real line among comments is enough to be worth parsing."""
+        assert skip_reason("", "# explain\nmake test") is None
+
+    def test_the_flag_is_reported_ahead_of_an_inferred_reason(self) -> None:
+        """Where a fence qualifies twice, the explicit instruction is what is reported.
+
+        Not cosmetic: the log line is how a reader learns why a fence went unchecked, and
+        "the author excluded it" and "we decided it was a tree" are different facts.
+        """
+        assert skip_reason(" +RHIZA_SKIP", "# see the Makefile") == "+RHIZA_SKIP flag"
+        assert skip_reason(" +RHIZA_SKIP", "a\n└── b") == "+RHIZA_SKIP flag"
+
+
+class TestClassifyBashBlocks:
+    """Tests for enumerating a document's bash fences with their verdicts."""
+
+    def test_indexes_count_every_fence_including_excluded_ones(self) -> None:
+        """The index names the fence a reader counting fences would name.
+
+        This is the reason the index is carried rather than recomputed over the parsed
+        subset: "Bash block 2 has syntax errors" has to mean the third fence in the file,
+        not the third *checked* one.
+        """
+        doc = "```bash +RHIZA_SKIP\nrm -rf /\n```\n```bash\n# just a note\n```\n```bash\nmake test\n```\n"
+        assert [(i, reason) for i, _code, reason in classify_bash_blocks(doc)] == [
+            (0, "+RHIZA_SKIP flag"),
+            (1, "only comments"),
+            (2, None),
+        ]
+
+    def test_a_document_with_no_bash_fences_is_empty(self) -> None:
+        """A Rust or Go README may legitimately have none; that is not an error."""
+        assert classify_bash_blocks("# Title\n\nProse only.\n") == []
+
+    def test_python_fences_are_not_collected(self) -> None:
+        """Only bash fences — the python half belongs to test_readme_validation."""
+        assert classify_bash_blocks("```python\nprint(1)\n```\n") == []
+
+    def test_the_fence_body_is_returned_verbatim(self) -> None:
+        """The body is what gets piped to `bash -n`, so it must not be reshaped."""
+        [(_index, code, _reason)] = classify_bash_blocks("```bash\nmake test\nmake lint\n```\n")
+        assert code == "make test\nmake lint\n"
 
 
 class TestSkipFlag:


### PR DESCRIPTION
Closes #35.

## Result

```
before   M TestReadmeBashFragments.test_bash_blocks_basic_syntax  C (13)
         C TestReadmeBashFragments                                C (14)

after    M TestReadmeBashFragments.test_bash_blocks_basic_syntax  A (4)
         C TestReadmeBashFragments                                A (5)
```

Nothing in `checks/test_readme.py` is above **A**. Every block in `_fences.py` is A too.

## What moved

Two helpers into `_fences`, which already owned `SKIP_FLAG`, `TREE_MARKERS` and `should_skip`:

| helper | job |
| --- | --- |
| `skip_reason(flags, code)` | the three exclusions, returning **why** rather than a bool |
| `classify_bash_blocks(text)` | every fence with its verdict, in document order |

Plus `_assert_parses(index, code)` in the check module for the `bash -n` call and the stdout+stderr detail assembly.

`skip_reason` returns a reason string rather than a boolean on purpose. The caller logs it, and *"skipped 4 of 6 fences"* with no explanation is the kind of green that hides a mistake. The index is likewise carried rather than recomputed over the parsed subset, so `Bash block 2 has syntax errors` still means the third fence in the file, not the third *checked* one.

## The tests this made possible

The three exclusions were previously inline `continue` branches, reachable only end-to-end through a subject repository and a README — so they had no direct tests. As a pure function of `(flags, code)` they now get twelve, including two edges that were **untested before**:

- **an inline comment does not exclude** — `make test  # runs the suite` still leaves a command that must parse
- **precedence when a fence qualifies twice** — `+RHIZA_SKIP` on a comment-only fence reports the flag, not `only comments`. Not cosmetic: "the author excluded it" and "we decided it was a tree" are different facts for a reader of the log.

Suite: **111 → 123 tests**. `_fences.py` stays at **100%** coverage; overall 98.95% → 98.96%.

## Behaviour

Unchanged, including the exact log phrasings `+RHIZA_SKIP flag`, `directory tree representation` and `only comments`. `tests/test_check_readme.py` asserts on pass counts and failure messages, both untouched — `3 passed` still.

Self-applied: `pytest --pyargs pytest_rhiza.checks.test_readme` → 3 passed.

## Note on `r"""`

The new docstrings are raw-prefixed, following `bash_usable`'s precedent, because the fence bodies in their examples need real `\n` escapes. Ruff's D301 requires it.

## Verification

- `make test` — 123 passed, 98.96%
- `uvx radon cc src/pytest_rhiza/checks/test_readme.py src/pytest_rhiza/_fences.py -a -s` — all A
- `make lint` — 8/8 hooks

## Merge note

`test_doctests` still shows C (19) on this branch — that is #33 / PR #40, a different file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)