### PR TITLE
docs: record the two design questions as settled, not open

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,18 +152,35 @@ Without it the check resolves `src` alone, and a project keeping its Python else
 its examples silently unchecked — rhiza's own repo being the extreme case, with no `src/`
 at all.
 
-## Two things still to decide
+## Two things that were decided
 
-**Version pinning.** Today the checks and the template move as one — `template.lock` pins
-a ref and the files come with it. A separate distribution adds a second version axis. The
-recipe above pins an exact version so there is still one number to reason about, but the
-sync has to *generate* that pin from the template release. The alternative is aligning
-this package's `major.minor` with template releases and pinning `~=`.
+Both of these were open questions while the split was being designed. They are settled
+now, and the second went the opposite way to what was expected — which is the more useful
+half to record.
 
-**Removing the old folder.** A consumer on the current template has `.rhiza/tests/` on
-disk. The sync ceasing to deliver it does not delete it, and a leftover copy would run
-twice as long as `pythonpath` still finds it. The migration PR needs an explicit removal
-step.
+**Version pinning: one number, and no literal in this file.** The worry was that a
+separate distribution adds a second version axis to reason about. It does not, because the
+pin travels in the template: it is one setting a consumer's sync writes, so a repo on a
+given template release runs that release's assertions, exactly as file-copy delivery gave
+for free. The alternative considered — aligning this package's `major.minor` with template
+releases and pinning `~=` — was not taken.
+
+What *did* need deciding was where the number is written, and the answer is nowhere in
+this README. Nothing here bumps it and, until #17, nothing read it either, so the
+documented pin sat at `0.1.0` for three releases. The example uses a placeholder, and
+`tests/test_readme_pin.py` is what keeps a literal from creeping back.
+
+**Removing the old folder: not required, because a leftover is inert.** The concern was
+that a consumer keeps `.rhiza/tests/` on disk (a sync ceasing to deliver a file does not
+delete it) and that the copy would then run twice, so a migration would need an explicit
+removal step.
+
+That was wrong, and for a reason worth knowing: the gate names **modules**, not paths. It
+resolves `pytest_rhiza.checks.*` out of site-packages, so it never looks at the folder —
+and `pythonpath = .rhiza/tests`, the one thing that used to make the folder importable, is
+itself one of the five costs above that the move removed. A leftover copy is unreachable
+rather than duplicated. `rhiza-test` warns while the folder is still present, and deleting
+it is tidying rather than a migration step.
 
 ## Development
 


### PR DESCRIPTION
Closes #36.

## The half that was real, and bigger than filed

"Two things still to decide" read as open. **Both are settled** — and the second was settled the *opposite* way to what the section predicted, which is the more useful thing to record.

### Version pinning

Closed by the placeholder plus `tests/test_readme_pin.py`, whose own docstring already states the decision and the reasoning (#17). The README went on presenting it as a live trade-off, so a reader met an open question that a test had already shut.

### Removing the old folder — the README was wrong

It claimed:

> a leftover copy would run twice as long as `pythonpath` still finds it. The migration PR needs an explicit removal step.

That is not what happens. The gate names **modules, not paths**: it resolves `pytest_rhiza.checks.*` out of site-packages and never looks at the folder. And `pythonpath = .rhiza/tests` — the one thing that used to make the folder importable — is *itself one of the five costs listed higher up the same README* that this move removed. So a leftover `.rhiza/tests/` is unreachable rather than duplicated; `rhiza-test` warns while it is present, and deleting it is tidying, not a migration step.

Confirmed against `jebel-quant/rhiza@v1.4.2`'s `CLAUDE.md`, which reaches the same conclusion independently:

> A consumer that syncs past #1540 keeps its old `.rhiza/tests/` on disk … Nothing runs it — the gate names modules, not paths — so it is inert rather than duplicated, and `rhiza-test` warns while the folder is still there.

A README predicting a migration hazard that does not exist is worse than one saying nothing: it invites work nobody needs to do.

## The half that was not real

**"All five go away" is correct and is unchanged.** The issue claimed the list above it has six bullets. It has five:

```
$ awk 'NR>=11 && NR<=20 && /^- /{n++} END{print n}' README.md
5
```

I had counted wrapped continuation lines as separate bullets when filing. Upstream's `CLAUDE.md` arrives at the same number independently — *"Five costs of the copy went with it"* — listing the same five items. Nothing to fix here, so nothing was touched.

## Also

The heading changed, so the one in-document anchor pointing at it (`#two-things-still-to-decide` at line 94) moved with it. No dangling link.

## Verification

- `make test` — 111 passed, 98.95%
- `pytest --pyargs …test_readme …test_readme_validation` — 5 passed, so the rewritten prose still satisfies our own README checks
- `make lint` — 8/8 hooks

## Merge note

Touches `README.md` in the same region as #37, which rewrites the make-wiring section and drops that anchor link entirely. Whichever lands second wants a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)