### PR TITLE
fix: bound every child process, and close three quality findings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 
 PREK := uvx prek
 
-.PHONY: help lint install-hooks typecheck docs-coverage security test clean
+.PHONY: help lint install-hooks typecheck docs-coverage security test rhiza-test clean
 
 help: ## Show this help
 	@grep -hE '^[a-zA-Z0-9_-]+:.*?## ' $(MAKEFILE_LIST) \
@@ -52,6 +52,29 @@ security: ## Bandit scan of src (mirrors the rhiza_ci "Security scanning" job)
 # checks only ever execute in child processes.
 test: ## Run the test suite with coverage
 	uv run --group test pytest -ra --cov=src --cov-report=term-missing --cov-fail-under=90
+
+# The checks this package ships, run against this repository (#47).
+#
+# README.md claimed `make rhiza-test` was what kept its module-list table honest, and no
+# such target existed: the fence was only ever executed by the upstream reusable workflow,
+# so a contributor could not reproduce a red check locally. That is the same hazard the
+# comment above `typecheck` names, one gate over — and the README naming a target that is
+# not there is worse than the gap it papers over.
+#
+# `test_cargo_toml` and `test_go_module` are absent from the list deliberately: there is no
+# Cargo.toml or go.mod here for them to judge, and a check with no subject would skip,
+# which reads as a pass (#34).
+#
+# RHIZA_DOCTEST_FOLDERS is left unset on purpose — this project's Python *is* under `src`,
+# which is the variable's own fallback, so setting it would add a second place to keep the
+# folder name correct. A consumer whose layout differs is the case the README documents.
+rhiza-test: ## Run this package's checks against this repository
+	uv run --group test pytest -ra --pyargs \
+		pytest_rhiza.checks.test_readme \
+		pytest_rhiza.checks.test_readme_validation \
+		pytest_rhiza.checks.test_pyproject \
+		pytest_rhiza.checks.test_docstrings \
+		pytest_rhiza.checks.test_release_tags
 
 clean: ## Remove build artefacts and caches
 	rm -rf dist build .pytest_cache .ruff_cache .coverage htmlcov *.egg-info src/*.egg-info

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ means a green pipeline:
 | `make docs-coverage` | interrogate over `src` and `tests`, at a 100% floor |
 | `make security` | bandit over `src` |
 | `make test` | the suite, with the 90% coverage gate |
+| `make rhiza-test` | the checks this package ships, against this repository |
 
 `typecheck`, `docs-coverage` and `security` take their flags from the reusable workflow
 `jebel-quant/rhiza/.github/workflows/rhiza_ci.yml`, so the recipes mirror those jobs
@@ -206,11 +207,18 @@ rather than setting a threshold of their own — see the comment above them in t
 `Makefile`.
 
 The checks run against this repository too — it is a Python project with a README, a
-`pyproject.toml` and a release config, so it is a valid subject for its own assertions:
+`pyproject.toml` and a release config, so it is a valid subject for its own assertions.
+That is what `make rhiza-test` is:
 
 ```bash
-uv run pytest --pyargs pytest_rhiza.checks.test_readme pytest_rhiza.checks.test_pyproject
+make rhiza-test
 ```
+
+It names the five modules this project is a subject for, and deliberately not
+`test_cargo_toml` or `test_go_module`: there is no `Cargo.toml` or `go.mod` here for them
+to judge, and a check with no subject skips, which reads as a pass (#34). The five come to
+the same 34 assertions the `(RHIZA) CI` job runs, so a green local sweep means a green
+pipeline here as well.
 
 ## License
 

--- a/src/pytest_rhiza/_fences.py
+++ b/src/pytest_rhiza/_fences.py
@@ -22,6 +22,8 @@ import functools
 import re
 import subprocess  # nosec B404
 
+from pytest_rhiza._process import inspect_timeout
+
 # Bash code blocks — captures optional flags (e.g. "+RHIZA_SKIP") and the code body.
 BASH_BLOCK = re.compile(r"```bash([^\n]*)\n(.*?)```", re.DOTALL)
 
@@ -185,8 +187,14 @@ def bash_usable() -> bool:
             input=_PROBE,
             capture_output=True,
             text=True,
+            timeout=inspect_timeout(),
         )
     except OSError:
         # bash is absent entirely, or not executable.
+        return False
+    except subprocess.TimeoutExpired:
+        # A `bash` that cannot parse `:` within the budget is not a usable bash. Reported
+        # the same way as an absent one rather than as a failure: this function's whole
+        # job is to answer "can this platform parse fences at all", and "it hung" is a no.
         return False
     return result.returncode == 0

--- a/src/pytest_rhiza/_process.py
+++ b/src/pytest_rhiza/_process.py
@@ -1,0 +1,192 @@
+"""Bounded child processes for the checks, and the one git executable they share.
+
+**Why every child needs an explicit timeout (#44).** The checks shell out for four
+things: git queries, ``bash -n`` fence parsing, the ``bash`` probe, and — the one that
+matters — executing the ``python`` fences out of a consumer's README. None of those calls
+carried a ``timeout`` before, so a fence that waits on ``input()``, blocks on a network
+call, or loops forever made the check *hang* rather than fail.
+
+It is tempting to answer that with ``pytest-timeout``, which this package depends on. That
+does not work, and the reason is worth writing down: pytest-timeout takes its bound from
+the ``timeout`` ini setting in the **consumer's** config, and nothing here sets a default.
+This repository's own ``pytest.ini`` says ``timeout = 60``, which is exactly why the gap
+was invisible from inside it. A consumer repository that never set the option gets no
+bound at all — and since pytest-rhiza is a runtime dependency of every rhiza-managed
+repository, an unbounded wait propagates into every consumer's CI, where a hung job is
+worse than a red one: it burns the runner's whole budget and reports nothing.
+
+So the bound lives here, in the code that spawns the process, where it does not depend on
+what the consumer configured.
+
+**Two budgets, because the calls differ in kind.** :data:`INSPECT_TIMEOUT` covers the
+processes that only *look* at something — git answering a question about its own object
+database, ``bash -n`` parsing a snippet it will never run. Those are sub-second
+operations; 30s is already pathological. :data:`EXECUTE_TIMEOUT` covers the single call
+that runs code someone wrote, where a legitimately slow example is imaginable, so it is
+generous by comparison.
+
+**Both are overridable, and that is not decoration.** The kill path is the whole point of
+the module, so it has to be testable, and no test can wait out a 120s budget — this
+package's own suite runs the hanging-fence case with ``RHIZA_EXECUTE_TIMEOUT=2``. Having
+built the knob for that, it is also the answer for a consumer whose example genuinely
+needs longer, which is the case the defaults cannot know about.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess  # nosec B404
+from pathlib import Path
+
+import pytest
+
+# Resolved once, through PATH rather than at a fixed location: the Windows leg of the
+# matrix has git somewhere else entirely, and `shutil.which` is what makes the same code
+# work there. The fallback is for the case where PATH has been emptied deliberately —
+# some of this package's own tests do exactly that — and is expected to fail loudly rather
+# than silently resolve something else.
+GIT = shutil.which("git") or "/usr/bin/git"
+
+# Processes that only inspect: git queries, `bash -n`, the bash probe.
+INSPECT_TIMEOUT = 30
+INSPECT_TIMEOUT_ENV = "RHIZA_INSPECT_TIMEOUT"
+
+# The one process that executes documentation: a README's python fences.
+EXECUTE_TIMEOUT = 120
+EXECUTE_TIMEOUT_ENV = "RHIZA_EXECUTE_TIMEOUT"
+
+
+def _budget(name: str, default: int) -> int:
+    """Return the timeout named by an environment variable, or ``default``.
+
+    A value that is not a positive integer falls back to the default rather than raising.
+    The reason is what this number *is*: a safety net over a child process. A typo in an
+    environment variable must not be able to remove the net, and must not be able to break
+    every check in the repository either — both of which a propagating ``ValueError`` here
+    would do, at the cost of a setting nobody needs to get right for the gate to work.
+
+    Args:
+        name: The environment variable to read.
+        default: Seconds to use when it is unset or unusable.
+
+    Returns:
+        The budget in seconds.
+
+    Examples:
+        Unset means the default:
+
+        >>> import os
+        >>> _budget("RHIZA_BUDGET_EXAMPLE", 30)
+        30
+
+        A positive integer wins:
+
+        >>> os.environ["RHIZA_BUDGET_EXAMPLE"] = "5"
+        >>> _budget("RHIZA_BUDGET_EXAMPLE", 30)
+        5
+
+        Anything else falls back, rather than raising or disabling the bound — a typo and
+        a deliberate zero are both refused:
+
+        >>> os.environ["RHIZA_BUDGET_EXAMPLE"] = "soon"
+        >>> _budget("RHIZA_BUDGET_EXAMPLE", 30)
+        30
+        >>> os.environ["RHIZA_BUDGET_EXAMPLE"] = "0"
+        >>> _budget("RHIZA_BUDGET_EXAMPLE", 30)
+        30
+        >>> del os.environ["RHIZA_BUDGET_EXAMPLE"]
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        seconds = int(raw)
+    except ValueError:
+        return default
+    return seconds if seconds > 0 else default
+
+
+def inspect_timeout() -> int:
+    """Return the budget for a child that only inspects something.
+
+    Returns:
+        Seconds, from :data:`INSPECT_TIMEOUT_ENV` or :data:`INSPECT_TIMEOUT`.
+    """
+    return _budget(INSPECT_TIMEOUT_ENV, INSPECT_TIMEOUT)
+
+
+def execute_timeout() -> int:
+    """Return the budget for the child that executes a README's python fences.
+
+    Returns:
+        Seconds, from :data:`EXECUTE_TIMEOUT_ENV` or :data:`EXECUTE_TIMEOUT`.
+    """
+    return _budget(EXECUTE_TIMEOUT_ENV, EXECUTE_TIMEOUT)
+
+
+def run(
+    argv: list[str],
+    *,
+    cwd: Path | None = None,
+    stdin: str | None = None,
+    timeout: int | None = None,
+    on_timeout: str = "the child process did not terminate",
+) -> subprocess.CompletedProcess[str]:
+    """Run one child process to completion, failing the test if it outlives its budget.
+
+    Args:
+        argv: The argument list. Always a list, never a string — there is no shell here.
+        cwd: Directory to run in, or None for the current one.
+        stdin: Text to write to the child's stdin, or None to give it none.
+        timeout: Seconds to wait before killing it, or None for :func:`inspect_timeout`.
+        on_timeout: What to tell the reader when it is killed. Callers supply this because
+            only they know what a hang *means* — a fence that never returns and a git
+            query that never answers need different next steps.
+
+    Returns:
+        The completed process, with stdout and stderr captured as text.
+
+    Raises:
+        Failed: via :func:`pytest.fail`, when the child exceeds its budget. Reported as a
+            failure rather than a skip: a process that had to be killed is a finding about
+            the repository under test, and a skip here would read as a pass — the failure
+            mode this package already fights elsewhere (#34).
+    """
+    budget = inspect_timeout() if timeout is None else timeout
+    try:
+        return subprocess.run(  # noqa: S603 - fixed argument list, no shell  # nosec B603
+            argv,
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            input=stdin,
+            timeout=budget,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(f"Killed after {budget}s: {on_timeout}")
+
+
+def git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run one read-only git query inside ``root``.
+
+    The return code is deliberately not checked. Every caller here distinguishes "git said
+    no" from "git failed" itself, and several treat a non-zero exit as a skip rather than
+    an error.
+
+    Args:
+        root: Repository to run in.
+        args: Arguments after the git executable.
+
+    Returns:
+        The completed process, with stdout and stderr captured as text.
+    """
+    return run(
+        [GIT, *args],
+        cwd=root,
+        on_timeout=(
+            f"`git {args[0] if args else ''}` never answered in {root}. The repository may be "
+            f"mid-operation (an index lock, an interrupted rebase) or very large; `git status` "
+            f"there is the first thing to check."
+        ),
+    )

--- a/src/pytest_rhiza/checks/test_docstrings.py
+++ b/src/pytest_rhiza/checks/test_docstrings.py
@@ -239,25 +239,28 @@ def _iter_package_modules(logger, monkeypatch, src_path: Path, import_root: Path
         import_root: The directory prepended to ``sys.path`` for that folder.
 
     Yields:
-        Each imported module. A package that cannot be walked is warned about and
-        skipped, for the same reason a module is: not measuring something is a different
-        statement from finding it wrong.
+        Each imported module. A module that cannot be imported is warned about and skipped
+        by :func:`_iter_modules_from_path`, one module at a time — not measuring something
+        is a different statement from finding it wrong.
     """
     # No `is_dir() and (package_dir / "__init__.py").exists()` guard: the inline version
     # had one, and inverting it to a `continue` made visible that it can never fire.
     # `_find_packages` globs `__init__.py` and yields each match's parent, so both halves
     # are true by construction — the guard was an uncoverable branch asserting the
     # postcondition of the generator two lines above it.
+    #
+    # And no `except ImportError` around the `list()` either, for the same reason (#45).
+    # `_iter_modules_from_path` catches ImportError around its own `import_module` call and
+    # continues, so no ImportError can escape the generator for a handler here to see —
+    # the walk raising one would mean that handler had stopped working. It was 4 of the 6
+    # uncovered lines in the package and could not be tested, because there is no repo
+    # state that reaches it. Per-module is also the better granularity: one unimportable
+    # module no longer costs the measurement of its siblings.
     for package_dir in _find_packages(src_path):
         package_name = package_dir.name
         logger.info("Discovered package: %s", package_name)
         _evict_shadowing_package(monkeypatch, logger, import_root, package_dir)
-        try:
-            modules = list(_iter_modules_from_path(logger, package_dir, import_root))
-        except ImportError as e:
-            warnings.warn(f"Could not import package {package_name}: {e}", stacklevel=2)
-            logger.warning("Could not import package %s: %s", package_name, e)
-            continue
+        modules = list(_iter_modules_from_path(logger, package_dir, import_root))
         logger.debug("%d module(s) found in package %s", len(modules), package_name)
         yield from modules
 

--- a/src/pytest_rhiza/checks/test_readme.py
+++ b/src/pytest_rhiza/checks/test_readme.py
@@ -22,12 +22,12 @@ distribution is that home.
 
 from __future__ import annotations
 
-import subprocess  # nosec B404
 from pathlib import Path
 
 import pytest
 
 from pytest_rhiza._fences import BASH, bash_usable, classify_bash_blocks
+from pytest_rhiza._process import run
 
 
 def _assert_parses(index: int, code: str) -> None:
@@ -40,11 +40,14 @@ def _assert_parses(index: int, code: str) -> None:
     Raises:
         Failed: via :func:`pytest.fail`, when bash rejects the snippet.
     """
-    result = subprocess.run(  # nosec B603 B607 - `bash -n` parses without executing
+    result = run(
         [BASH, "-n"],
-        input=code,
-        capture_output=True,
-        text=True,
+        stdin=code,
+        on_timeout=(
+            f"`bash -n` never finished parsing block {index}. It parses without executing, "
+            f"so this is the shell itself wedging rather than the fence running — see "
+            f"`pytest_rhiza._fences.bash_usable` for the platform this tends to be."
+        ),
     )
     if result.returncode == 0:
         return

--- a/src/pytest_rhiza/checks/test_readme_validation.py
+++ b/src/pytest_rhiza/checks/test_readme_validation.py
@@ -18,12 +18,50 @@ independently and a shared helper would need a third home both bundles ship; one
 distribution is that home.
 """
 
-import subprocess  # nosec B404
+import difflib
 import sys
 
 import pytest
 
 from pytest_rhiza._fences import CODE_BLOCK, RESULT, SKIP_FLAG, should_skip
+from pytest_rhiza._process import execute_timeout, run
+
+
+def _mismatch(code_blocks, result_blocks, expected, actual):
+    """Explain an output mismatch, as the message for the assertion that found it (#46).
+
+    The assertion this serves used to carry no message at all, which mattered more here
+    than it looks: every ``python`` fence is executed as *one* script and diffed against
+    *all* the ``result`` fences merged, so pytest's own output was two opaque blobs with no
+    indication of which fence had drifted. This says how the merge works, so the reader can
+    map a diff line back to a fence, and shows the difference as a diff rather than as two
+    values to compare by eye.
+
+    Args:
+        code_blocks: The non-skipped python fence bodies, in document order.
+        result_blocks: The ``result`` fence bodies, in document order.
+        expected: The merged documented output.
+        actual: What the merged script actually printed.
+
+    Returns:
+        The failure message.
+    """
+    diff = "\n".join(
+        difflib.unified_diff(
+            expected.strip().splitlines(),
+            actual.strip().splitlines(),
+            fromfile="documented (```result``` fences)",
+            tofile="actual (stdout)",
+            lineterm="",
+        )
+    )
+    return (
+        f"README output does not match its documented result.\n\n"
+        f"{len(code_blocks)} python fence(s) are concatenated into one script and its stdout "
+        f"compared against {len(result_blocks)} ```result``` fence(s) concatenated in document "
+        f"order — so line N of the diff below is line N of that merged text, and counting "
+        f"``result`` fences from the top of the README names the one to fix.\n\n{diff}"
+    )
 
 
 def test_readme_runs(logger, root):
@@ -53,8 +91,22 @@ def test_readme_runs(logger, root):
 
     # Trust boundary: we execute Python snippets sourced from README.md in this repo.
     # The README is part of the trusted repository content and reviewed in PRs.
+    #
+    # Bounded, because this is the one call in the package that runs code somebody wrote
+    # rather than inspecting something (#44). An example that waits on `input()` or blocks
+    # on a network call used to hang the gate instead of failing it — and a hung CI job
+    # reports nothing while spending the whole runner budget.
     logger.debug("Executing README code via %s -c ...", sys.executable)
-    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, cwd=root)  # nosec
+    result = run(
+        [sys.executable, "-c", code],
+        cwd=root,
+        timeout=execute_timeout(),
+        on_timeout=(
+            f"the README's python fences did not finish. They are executed as one script, so "
+            f"one example waiting for input, blocking on the network, or looping forever stops "
+            f"all of them. Make it terminate, or mark that fence ```python {SKIP_FLAG}```."
+        ),
+    )
 
     stdout = result.stdout
     logger.debug("Execution finished with return code %d", result.returncode)
@@ -64,7 +116,7 @@ def test_readme_runs(logger, root):
 
     assert result.returncode == 0, f"README code exited with {result.returncode}. Stderr:\n{result.stderr}"
     logger.info("README code executed successfully; comparing output to expected result")
-    assert stdout.strip() == expected.strip()
+    assert stdout.strip() == expected.strip(), _mismatch(code_blocks, result_blocks, expected, stdout)
     logger.info("README code output matches expected result")
 
 

--- a/src/pytest_rhiza/checks/test_release_tags.py
+++ b/src/pytest_rhiza/checks/test_release_tags.py
@@ -13,13 +13,11 @@ places changelog boundaries at tags. An unreachable tag breaks both.
 
 from __future__ import annotations
 
-import shutil
-import subprocess  # nosec B404
 from pathlib import Path
 
 import pytest
 
-_GIT = shutil.which("git") or "/usr/bin/git"
+from pytest_rhiza._process import git
 
 
 def test_latest_tag_is_reachable_from_a_branch(latest_tag: str, root: Path) -> None:
@@ -36,26 +34,14 @@ def test_latest_tag_is_reachable_from_a_branch(latest_tag: str, root: Path) -> N
     folds its commits into the next release. Bump tooling reading the version from
     ``git describe`` skips the release for the same reason.
     """
-    if (
-        subprocess.run(  # nosec B603
-            [_GIT, "rev-parse", "--is-shallow-repository"], capture_output=True, text=True, cwd=root
-        ).stdout.strip()
-        == "true"
-    ):
+    if git(root, "rev-parse", "--is-shallow-repository").stdout.strip() == "true":
         pytest.skip("shallow clone — the commit graph is incomplete")
 
-    commit = subprocess.run(  # nosec B603
-        [_GIT, "rev-parse", f"{latest_tag}^{{commit}}"], capture_output=True, text=True, cwd=root
-    )
+    commit = git(root, "rev-parse", f"{latest_tag}^{{commit}}")
     if commit.returncode != 0:
         pytest.skip(f"tagged commit for {latest_tag} is not present locally")
 
-    contains = subprocess.run(  # nosec B603
-        [_GIT, "branch", "-a", "--contains", commit.stdout.strip(), "--format=%(refname:short)"],
-        capture_output=True,
-        text=True,
-        cwd=root,
-    )
+    contains = git(root, "branch", "-a", "--contains", commit.stdout.strip(), "--format=%(refname:short)")
     assert contains.stdout.strip(), (
         f"Tag {latest_tag} points at {commit.stdout.strip()[:12]}, which no branch contains. "
         f"It is most likely the pre-squash commit of a squash-merged release branch: "

--- a/src/pytest_rhiza/plugin.py
+++ b/src/pytest_rhiza/plugin.py
@@ -17,12 +17,10 @@ from __future__ import annotations
 
 import logging
 import pathlib
-import shutil
-import subprocess  # nosec B404
 
 import pytest
 
-_GIT = shutil.which("git") or "/usr/bin/git"
+from pytest_rhiza._process import git
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -156,12 +154,7 @@ def latest_tag(root: pathlib.Path) -> str:
     Returns:
         str: The highest version tag, e.g. ``v1.3.1``.
     """
-    result = subprocess.run(  # noqa: S603 - fixed argument list, no shell  # nosec B603
-        [_GIT, "tag", "--list", "v*", "--sort=-version:refname"],
-        capture_output=True,
-        text=True,
-        cwd=root,
-    )
+    result = git(root, "tag", "--list", "v*", "--sort=-version:refname")
     tags = [line.strip() for line in result.stdout.splitlines() if line.strip()]
     if not tags:
         pytest.skip("No version tags found in repository")

--- a/tests/test_check_readme.py
+++ b/tests/test_check_readme.py
@@ -14,6 +14,7 @@ comments — plus the whole of the python-fence half.
 from __future__ import annotations
 
 from collections.abc import Callable
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -91,6 +92,33 @@ class TestBashFenceExclusions:
 
         assert result.returncode != 0
         assert "README.md not found at project root" in result.stdout, result.stdout
+
+    def test_a_platform_without_bash_skips_rather_than_inventing_errors(
+        self, subject: Callable[..., Subject], tmp_path: Path
+    ) -> None:
+        """With no usable bash, the fence check skips and says so (#45).
+
+        One of the three silent-skip paths #45 was filed for: it was the only uncovered
+        line in this module, and an untested skip is the failure mode this package fights
+        hardest — a skip reads as a pass (#34).
+
+        Driven by emptying the child's PATH, which is deterministic on every platform this
+        is tested on: with nothing to resolve, `bash` raises OSError and the probe answers
+        False. On Windows `CreateProcess` can still reach System32's WSL launcher, but that
+        stub exits non-zero having written nothing, so the probe answers False there too —
+        both roads lead to the skip, which is why this is asserted rather than guarded.
+        Only a runner with a working WSL distribution would take the other branch, and the
+        images this is tested on have none.
+        """
+        empty = tmp_path / "no-tools"
+        empty.mkdir()
+        repo = subject({"README.md": "# Demo\n\n```bash\nmake install\n```\n"}, tag="v1.2.3")
+
+        result = repo.run("test_readme", env={"PATH": str(empty)})
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "no working `bash -n` on this platform" in result.stdout, result.stdout
+        assert "1 skipped" in result.stdout, result.stdout
 
 
 class TestPythonFenceExecution:
@@ -175,6 +203,79 @@ class TestPythonFenceExecution:
 
         assert result.returncode != 0
         assert "has syntax error" in result.stdout, result.stdout
+
+    def test_the_mismatch_message_explains_the_merge_and_shows_a_diff(self, subject: Callable[..., Subject]) -> None:
+        """A drifted result is reported with enough detail to find the fence (#46).
+
+        The assertion that catches this used to carry no message, which mattered because
+        of how the check works: all python fences run as *one* script and all ``result``
+        fences are compared as *one* string, so pytest's own output was two opaque blobs.
+        Two fences here, and the second one drifts, so the message has to do the
+        attribution the reader cannot do by eye.
+
+        ``--tb=long`` overrides the harness default of ``--tb=line``, which shows only the
+        first line of a failure and would hide the very thing under test.
+        """
+        readme = """
+        # Demo
+
+        ```python
+        print("first")
+        ```
+
+        ```result
+        first
+        ```
+
+        ```python
+        print("second")
+        ```
+
+        ```result
+        SECOND
+        ```
+        """
+        repo = subject({"README.md": readme}, tag="v1.2.3")
+
+        result = repo.run("test_readme_validation", args=("--tb=long",))
+
+        assert result.returncode != 0
+        assert "2 python fence(s)" in result.stdout, result.stdout
+        assert "2 ```result``` fence(s)" in result.stdout, result.stdout
+        # The diff names both sides, so the reader sees which is the documentation.
+        assert "-SECOND" in result.stdout, result.stdout
+        assert "+second" in result.stdout, result.stdout
+
+    def test_a_fence_that_never_terminates_is_killed_rather_than_hanging(self, subject: Callable[..., Subject]) -> None:
+        """A blocking example fails the gate instead of stopping it (#44).
+
+        Before the fix this test could not have been written: the call had no timeout, so
+        the check would have waited on ``time.sleep`` forever and taken the CI job with it.
+        The budget is shortened through the environment so the test costs two seconds
+        rather than the default two minutes — which is what that override is for.
+        """
+        readme = """
+        # Demo
+
+        ```python
+        import time
+
+        time.sleep(60)
+        print("never reached")
+        ```
+
+        ```result
+        never reached
+        ```
+        """
+        repo = subject({"README.md": readme}, tag="v1.2.3")
+
+        result = repo.run("test_readme_validation", env={"RHIZA_EXECUTE_TIMEOUT": "2"})
+
+        assert result.returncode != 0
+        assert "Killed after 2s" in result.stdout, result.stdout
+        # The message has to say what to do about it, not just that it happened.
+        assert "+RHIZA_SKIP" in result.stdout, result.stdout
 
     def test_a_readme_with_no_python_fences_passes(self, subject: Callable[..., Subject]) -> None:
         """Nothing to execute is not a defect; the empty code and result strings agree."""

--- a/tests/test_check_release_tags.py
+++ b/tests/test_check_release_tags.py
@@ -55,6 +55,29 @@ class TestReachability:
         assert result.returncode == 0, result.stdout + result.stderr
         assert "No version tags found" in result.stdout, result.stdout
 
+    def test_a_tag_that_does_not_resolve_to_a_commit_skips(self, subject: Callable[..., Subject]) -> None:
+        """A tag git cannot dereference to a commit is unjudgeable, not a failure (#45).
+
+        The third of the silent-skip paths #45 was filed for, and the one that looked
+        untestable: it needs ``git tag --list`` to report a tag while
+        ``git rev-parse <tag>^{commit}`` fails, on a repository that is *not* shallow — the
+        shallow branch above would otherwise fire first.
+
+        Tagging a tree object rather than a commit produces exactly that state. It is also
+        a real way to reach it: ``git tag v1 $(git rev-parse HEAD^{tree})`` is a plausible
+        slip, and the tag it leaves behind is reported by every listing while dereferencing
+        to a commit is an error. Reachability genuinely cannot be judged from it, so
+        skipping is right — but it has to be a skip that says why.
+        """
+        repo = subject({"README.md": "# Demo\n"})
+        tree = repo.git("rev-parse", "HEAD^{tree}").stdout.strip()
+        repo.git("tag", "v3.0.0", tree)
+
+        result = repo.run("test_release_tags")
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "tagged commit for v3.0.0 is not present locally" in result.stdout, result.stdout
+
     def test_a_shallow_clone_skips_because_the_graph_is_incomplete(self, subject: Callable[..., Subject]) -> None:
         """CI clones shallowly by default, and reachability cannot be judged from a truncated graph.
 

--- a/tests/test_fences.py
+++ b/tests/test_fences.py
@@ -196,6 +196,28 @@ class TestBashUsable:
         monkeypatch.setattr(_fences, "BASH", "no-such-shell-anywhere")
         assert bash_usable() is False
 
+    def test_rejects_a_bash_that_hangs(self, monkeypatch) -> None:
+        """A bash that cannot parse ``:`` inside the budget is not usable either (#44).
+
+        The probe is bounded like every other child process in the package, and the
+        verdict on a timeout is the same as on a missing binary rather than a failure:
+        this function's whole job is to answer "can this platform parse fences at all",
+        and "it never came back" is a no. Reporting it as a failure instead would accuse
+        every README of a defect the toolchain invented — the same mistake the WSL-stub
+        case above exists to prevent.
+
+        Faked, because a bash that hangs on ``:`` cannot be produced on demand.
+        """
+        bash_usable.cache_clear()
+
+        def _hangs(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            """Stand in for a bash that never returns."""
+            raise subprocess.TimeoutExpired(cmd=["bash", "-n"], timeout=1)
+
+        monkeypatch.setattr(_fences.subprocess, "run", _hangs)
+        assert bash_usable() is False
+        bash_usable.cache_clear()
+
     def test_accepts_an_interpreter_that_parses(self, monkeypatch) -> None:
         """A bash that exits zero is usable — the mirror of the silent-failure case."""
         bash_usable.cache_clear()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,0 +1,192 @@
+"""Tests for the bounded-subprocess layer every check shells out through.
+
+The module under test exists because none of those calls used to carry a ``timeout``
+(#44), so a README example that waited on ``input()`` made the gate *hang* rather than
+fail. What is asserted here is the half of that which no other test can reach: that a
+child outliving its budget is killed and reported, and that the budget is a number the
+environment can move — which is what makes the kill path testable in the first place, and
+therefore what stops this from being a safety net nobody has ever seen work.
+
+``_budget``'s precedence is doctested where it lives, so it is not re-asserted here. Its
+*refusals* are, because those are a safety property rather than documentation: a malformed
+override must not be able to remove the bound the module exists to provide.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pytest_rhiza._process import (
+    EXECUTE_TIMEOUT,
+    EXECUTE_TIMEOUT_ENV,
+    GIT,
+    INSPECT_TIMEOUT,
+    INSPECT_TIMEOUT_ENV,
+    execute_timeout,
+    git,
+    inspect_timeout,
+    run,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - import only for the fixture's type
+    from conftest import Subject
+
+# Long enough that no machine finishes it inside the one-second budget below, short enough
+# that a leaked child cannot outlive the suite.
+_SLEEP = "import time; time.sleep(30)"
+
+
+class TestBudgets:
+    """The two budgets, and the environment variables that move them."""
+
+    def test_the_defaults_apply_when_nothing_is_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unconfigured consumer still gets a bound — the whole point of #44."""
+        monkeypatch.delenv(INSPECT_TIMEOUT_ENV, raising=False)
+        monkeypatch.delenv(EXECUTE_TIMEOUT_ENV, raising=False)
+
+        assert inspect_timeout() == INSPECT_TIMEOUT
+        assert execute_timeout() == EXECUTE_TIMEOUT
+
+    def test_executing_gets_a_longer_budget_than_inspecting(self) -> None:
+        """The ordering is the design, not an accident of two literals.
+
+        Inspecting is git answering a question and `bash -n` parsing a string; executing
+        runs code somebody wrote. If these ever crossed, the generous budget would be on
+        the call that cannot legitimately need it.
+        """
+        assert EXECUTE_TIMEOUT > INSPECT_TIMEOUT
+
+    def test_the_environment_can_move_each_budget(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Independently, so shortening one for a test does not loosen the other."""
+        monkeypatch.setenv(INSPECT_TIMEOUT_ENV, "7")
+        monkeypatch.setenv(EXECUTE_TIMEOUT_ENV, "11")
+
+        assert inspect_timeout() == 7
+        assert execute_timeout() == 11
+
+    def test_an_unusable_override_falls_back_rather_than_removing_the_bound(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A typo must neither disable the timeout nor break every check.
+
+        Both halves matter. Falling back keeps the safety net that a malformed value would
+        otherwise remove; not raising keeps one stray environment variable from failing
+        every check in the repository with a traceback about ``int()``. Zero and negatives
+        are refused because neither means what someone setting them intended:
+        ``subprocess.run(timeout=0)`` kills the child immediately, and a negative raises
+        inside ``subprocess`` itself.
+        """
+        for value in ("soon", "", "1.5", "0", "-5"):
+            monkeypatch.setenv(EXECUTE_TIMEOUT_ENV, value)
+
+            assert execute_timeout() == EXECUTE_TIMEOUT, f"{value!r} should have fallen back to the default"
+
+
+class TestRun:
+    """Running one child to completion, and killing one that will not finish."""
+
+    def test_a_child_that_finishes_is_returned_verbatim(self) -> None:
+        """The ordinary case: output captured as text, return code untouched."""
+        result = run([sys.executable, "-c", "print('hello')"])
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "hello"
+
+    def test_a_non_zero_exit_is_returned_rather_than_raised(self) -> None:
+        """Callers decide what a failure means — several treat one as a skip."""
+        result = run([sys.executable, "-c", "raise SystemExit(3)"])
+
+        assert result.returncode == 3
+
+    def test_stdin_reaches_the_child(self) -> None:
+        """`bash -n` is fed its fence this way, so the plumbing is worth asserting."""
+        result = run([sys.executable, "-c", "import sys; print(sys.stdin.read().upper())"], stdin="fence")
+
+        assert result.stdout.strip() == "FENCE"
+
+    def test_a_child_that_outlives_its_budget_is_killed_and_reported(self) -> None:
+        """The defect #44 was filed for: a hang becomes a failure instead of a hang.
+
+        Driven at a one-second budget rather than through the real 120s one, which is the
+        reason the budgets are overridable at all — a test that waited out the default
+        would be a test nobody runs.
+        """
+        with pytest.raises(pytest.fail.Exception) as failure:
+            run([sys.executable, "-c", _SLEEP], timeout=1, on_timeout="the probe never came back")
+
+        assert "Killed after 1s" in str(failure.value)
+        assert "the probe never came back" in str(failure.value)
+
+    def test_the_budget_used_is_the_inspect_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An omitted `timeout` resolves through the environment, not to an unbounded wait.
+
+        Asserted through the failure message, which names the budget it exceeded: that
+        string is the only externally visible evidence of which number was applied.
+        """
+        monkeypatch.setenv(INSPECT_TIMEOUT_ENV, "1")
+
+        with pytest.raises(pytest.fail.Exception) as failure:
+            run([sys.executable, "-c", _SLEEP], on_timeout="unused")
+
+        assert "Killed after 1s" in str(failure.value)
+
+
+class TestGit:
+    """The shared git entry point, which every git-dependent check now goes through."""
+
+    def test_a_query_answers_from_the_given_root(self, subject: Callable[..., Subject]) -> None:
+        """`cwd` is the repository, not the directory the suite happens to run in."""
+        repo = subject({"README.md": "# Demo\n"}, tag="v1.2.3")
+
+        result = git(repo.path, "tag", "--list", "v*")
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "v1.2.3"
+
+    def test_a_failing_query_is_reported_by_return_code(self, subject: Callable[..., Subject]) -> None:
+        """Not raised: `test_release_tags` reads a non-zero exit here as a reason to skip."""
+        repo = subject({"README.md": "# Demo\n"})
+
+        result = git(repo.path, "rev-parse", "v9.9.9^{commit}")
+
+        assert result.returncode != 0
+
+    def test_the_executable_is_resolved_through_path(self) -> None:
+        """Resolved once at import, which is what makes the Windows leg work.
+
+        Neither assertion names a location — the path differs per platform and per runner,
+        and pinning one would be a test about this machine. What is asserted is the two
+        properties the resolution has to have: it is git, and it is a full path rather than
+        the bare name that `subprocess` would otherwise re-search on every call.
+        """
+        assert Path(GIT).stem == "git", GIT
+        assert Path(GIT).is_absolute(), GIT
+
+
+def test_no_check_shells_out_unbounded() -> None:
+    """No module under `checks/` may call `subprocess.run` directly (#44).
+
+    The regression guard for the whole issue. Bounding the seven call sites that existed
+    is a fix; routing every future one through :func:`run` is what stops the eighth from
+    reintroducing the hang. `_fences` is the one exception, and it is exempt on purpose:
+    its probe has to answer False on a timeout rather than fail, so it owns its own call —
+    with a `timeout=` argument, which is what the sibling test in `test_fences.py` covers.
+    """
+    import pytest_rhiza.checks as checks
+
+    offenders = [
+        path.name
+        for path in sorted(Path(next(iter(checks.__path__))).glob("*.py"))
+        if "subprocess.run" in path.read_text(encoding="utf-8")
+    ]
+
+    assert not offenders, (
+        f"{offenders} call subprocess.run directly instead of pytest_rhiza._process.run, so "
+        f"their children are bounded only by whatever the consumer happened to configure — "
+        f"which is the unbounded-wait defect in #44."
+    )


### PR DESCRIPTION
Fixes the four findings from a `/rhiza:quality` run. One branch rather than four,
because #44's new module is what #45's and #46's tests are written against.

## #44 — every child process is now bounded

No `subprocess.run` in `src/` carried a `timeout`, so a README fence that waits on
`input()`, blocks on a network call, or loops forever made the check **hang** rather
than fail.

`pytest-timeout` cannot cover this, and the reason is the interesting part: it reads its
bound from the **consumer's** `timeout` ini setting, and nothing here set a default. This
repository's own `pytest.ini` says `timeout = 60`, which is exactly why the gap was
invisible from inside it. A consumer that never set the option got no bound at all — in a
package every rhiza-managed repository depends on at runtime, where a hung CI job is worse
than a red one: it spends the whole runner budget and reports nothing.

New `src/pytest_rhiza/_process.py` owns the bound, the two budgets, and the `GIT`
executable that `plugin.py` and `checks/test_release_tags.py` had each been resolving
separately. All seven call sites route through it.

**Both budgets are environment-overridable, and that is load-bearing rather than
decorative.** It was not in the original plan — a knob nobody asked for is a second home
for a number. But the issue asks for a test that a hanging fence *fails rather than hangs*,
and no test can wait out a 120s default, so without the override the kill path would have
been a safety net nobody had ever seen work. A malformed value falls back to the default
rather than raising: a typo must be able neither to remove the bound nor to break every
check in the repository.

`tests/test_process.py` also adds `test_no_check_shells_out_unbounded`, asserting no module
under `checks/` calls `subprocess.run` directly. Bounding seven call sites is a fix; that
guard is what stops the eighth.

## #45 — the three silent-skip paths

All six previously-uncovered lines were skip-or-warn escape hatches, which is the "a
skipped assertion reads as a pass" failure mode this package already fights hardest (#34).

Two are now tested:

- **no usable bash** — the child's `PATH` is emptied, so the probe answers False on every
  platform this is tested on;
- **a tag that will not dereference to a commit** — a tag pointing at a *tree* object
  reaches the branch on a non-shallow repository, and is a plausible real slip
  (`git tag v1 $(git rev-parse HEAD^{tree})`).

The third, `_iter_package_modules`' `except ImportError`, turned out to be **unreachable**:
`_iter_modules_from_path` already catches `ImportError` around its own `import_module` and
continues, so nothing can escape the generator for the outer handler to see. Removed rather
than tested — the same call this function already documents making six lines above, for the
uncoverable `is_dir()` guard. Per-module is also the better granularity: one unimportable
module no longer costs its siblings their measurement.

## #46 — the output-diff assertion says something now

`assert stdout.strip() == expected.strip()` carried no message, which mattered because of
how the check works: all python fences execute as **one** script and all ` ```result `
fences are compared as **one** string, so pytest printed two opaque blobs with no
indication of which fence had drifted. It now explains the merge and shows a unified diff
labelled documented-vs-actual.

## #47 — `make rhiza-test` exists

`README.md` claimed that target was what kept its module-list table honest. It did not
exist, so the fence was only ever executed by the upstream reusable workflow — the same
hazard the `Makefile` comment names when explaining why `typecheck`, `docs-coverage` and
`security` were given local entry points, one gate over.

Added, naming the five modules this project is a valid subject for, and deliberately not
`test_cargo_toml` or `test_go_module`: there is no `Cargo.toml` or `go.mod` here for them
to judge, and a check with no subject skips. The five come to the same 34 assertions the
`(RHIZA) CI` job runs.

## Gates

| Gate | Before | After |
| --- | --- | --- |
| `make lint` (8 hooks) | PASS | PASS |
| `make typecheck` | PASS | PASS |
| `make docs-coverage` | 100% / 297 | 100% / 327 |
| `deptry` | PASS | PASS |
| `make security` | PASS + 7 warnings | **PASS, silent** |
| `make test` | 123 tests, 98.99% | **141 tests, 100.00%** |
| `make rhiza-test` | did not exist | **34 passed, 0 skipped** |
| doctests + README fences, executed | 62 examples | **71 examples**, 0 violations |
| average cyclomatic complexity | 2.98 (A) | 2.93 (A), nothing above B |

Two side effects worth naming. Coverage reached 100% against a 90% floor. And
`make security` went silent: the `# nosec B603 B607 - prose` comment bandit was parsing as
test names went with the refactor, which was a separate low-priority finding from the same
assessment.

Architecture stays a DAG — `checks/` → {`_bumpversion`, `_fences`, `_process`},
`_fences` → `_process` — with no cycles, module-level or function-local.

The CI `self-check` job's exact command still reports 28 passed / 0 skipped, so its
skip-grep guard stays green.

Closes #44
Closes #45
Closes #46
Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)
