### PR TITLE
Close out #52 and #53: correct the one README paragraph they left stale

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,13 +254,14 @@ The job names the five modules this project is a subject for, and deliberately n
 `test_cargo_toml` or `test_go_module`: there is no `Cargo.toml` or `go.mod` here for them
 to judge, and a check with no subject skips, which reads as a pass (#34).
 
-The five come to 34 assertions, and locally all 34 *run* — which is the part worth
-checking, because the upstream `Rhiza repository checks` job reports `32 passed, 2
-skipped`: its checkout fetches no tags, so the two assertions comparing
-`[project].version` against the newest `vX.Y.Z` have nothing to compare and skip. That is
-the one place where local is *stronger* than that job rather than weaker, and it is why
-`ci.yml` carries a `self-check` job that re-runs those two with `fetch-depth: 0` and fails
-if anything skips at all (#34).
+The five come to 34 assertions, and all 34 *run* — which is the part worth checking,
+because rhiza's own `Rhiza repository checks` job used to report `32 passed, 2
+skipped`: its checkout fetched no tags, so the two assertions comparing
+`[project].version` against the newest `vX.Y.Z` had nothing to compare and skipped. That is
+the one place where local was *stronger* than that job rather than weaker, and it is why
+the `rhiza-test` job checks out with `fetch-depth: 0` and then fails if anything skipped at
+all (#34) — fetching tags fixes today's symptom, and the no-skip guard is what stops the
+failure mode returning through some other change.
 
 ## License
 


### PR DESCRIPTION
The substance of **#53** (drop python-dotenv) and **#52** (own this repo's CI outright)
landed in #54, merged earlier today. Verified against both `done when` lists on `main`:

**#53** — `python-dotenv` is absent from `[project].dependencies` and from `uv.lock`; the
`[tool.deptry.package_module_name_map]` table is gone (a comment records why it existed);
`_read_rhiza_env` parses `.rhiza/.env` with the stdlib and its tolerance for malformed
lines is covered by a doctest plus unit tests; the shadowing test's victim is now `pluggy`,
which pytest guarantees is in `sys.modules` before the walk starts. Suite: **142 passed,
100% coverage**.

**#52** — `rhiza_ci.yml`, `rhiza_weekly.yml` and the `Makefile` are gone; `ci.yml` defines
all ten gates plus the `ci-gate` aggregator; `weekly.yml` carries dep-compat and
link-check; `rhiza_codeql.yml`, `rhiza_scorecard.yml` and `rhiza_release.yml` stay.

## What this PR fixes

One thing #52 left behind: the README's closing paragraph still described the pre-#52
arrangement.

- It pointed at a **`self-check` job that does not exist**. The behaviour it described
  (tags fetched, fail on any skip) lives inside `rhiza-test`, so a reader who greps for
  `self-check` finds nothing — worse than no pointer at all.
- It described rhiza's `Rhiza repository checks` job in the **present tense**, as though it
  still judged this repository. It does not, since #52 — the comparison is history now.

Wording only. No gate, threshold or command line changes.

## Verification

- `uv run --group test pytest --cov` → 142 passed, 100%
- the five self-applied modules → **34 passed, 0 skipped**

Closes #52
Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)