### PR TITLE
feat: give the gates a local entry point, and add mypy --strict beside ty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,13 @@ name: CI
 # So the gates are defined here, in full, and nothing in this file invokes rhiza or
 # rhiza-task. The one remaining rhiza_*.yml stub is a deliberate exception, below.
 #
-# The cost is stated plainly because it is real: there is no *runnable* local entry point
-# any more (#49, #32) — no Makefile, no task runner. That was a deliberate call — see #52 —
-# on the grounds that a Makefile in a repo whose ecosystem retired make as an interface is a
-# second thing to keep correct. Reproducing a red gate means copying its command line, which
-# since #58 is a paste out of the README rather than a read of this YAML.
+# There is still no Makefile and no task runner, and nothing here invokes rhiza-task. What
+# changed at #66 is that `scripts/gates.py` gives the gates a local entry point again — and
+# it does so without becoming the second home #52 removed, because it holds no recipes: it
+# parses the README fence this file is pinned to and runs what is written there. So the
+# ordering stands unchanged: this file defines, the README copies, the test pins, the runner
+# executes. Reproducing a red gate is `python scripts/gates.py <gate>`; the older paths —
+# a paste out of the README (#58), or reading this YAML (#49, #32) — both still work.
 #
 # `rhiza_codeql.yml` and `rhiza_scorecard.yml` are gone too. They called out to rhiza's
 # reusable CodeQL and OSSF Scorecard workflows, which meant a pinned edge to maintain for
@@ -119,7 +121,7 @@ jobs:
           pytest -ra --cov=src --cov-report=term-missing --cov-fail-under=90
 
   typecheck:
-    name: Type checking (ty)
+    name: Type checking (ty + mypy --strict)
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -130,12 +132,36 @@ jobs:
         with:
           enable-cache: true
 
-      # src only, deliberately: tests/ leans on pytest fixtures and monkeypatching that
-      # a strict checker reads as untyped, and typing them would be noise rather than
-      # safety. `--with ty` rather than a dependency-group entry so the checker does not
-      # enter the runtime resolution of a package every rhiza-managed repo installs.
+      # `src` and `scripts`, but not `tests/`: the suite leans on pytest fixtures and
+      # monkeypatching that a strict checker reads as untyped, and typing it would be
+      # noise rather than safety. `scripts/` is ordinary annotated code and is checked
+      # like the package — it arrived with the gate runner (#66), and a new source
+      # directory outside every gate is how a blind spot becomes permanent.
+      #
+      # `--with ty` rather than a dependency-group entry so the checker does not enter the
+      # runtime resolution of a package every rhiza-managed repo installs.
       - name: Type-check src
-        run: uv run --with ty ty check src
+        run: uv run --with ty ty check src scripts
+
+      # Two checkers, because they answer different questions and the second one found
+      # things the first accepts (#67). `ty` infers and reports what it can prove wrong;
+      # `--strict` additionally *demands annotations*, which is a policy `ty` has no
+      # opinion on. On adoption it reported 61 errors over 7 files that `ty` passed
+      # clean: 40 bare `dict` annotations (i.e. `dict[Any, Any]`, erasing the known-`str`
+      # key type of every parsed TOML table), 18 unannotated functions, and two returns
+      # of `Any` from functions declaring a concrete type. One of those two was a real
+      # disagreement, not a notation gap — `bumpversion_table` handed back a non-table
+      # `tool.bumpversion` that `has_bumpversion_section` reported as absent.
+      #
+      # Keeping both is the point: dropping `ty` loses fast inference on every push,
+      # dropping mypy loses the annotation floor that keeps `Any` from spreading back in.
+      #
+      # No `[tool.mypy]` table, for the same reason interrogate's threshold and the
+      # coverage floor are not mirrored into pyproject.toml: one home per setting. The
+      # flags are here. And no `--group test` — pytest is a *runtime* dependency of this
+      # package, so `uv run` already resolves it and the stubs are present.
+      - name: Type-check src strictly
+        run: uv run --with mypy mypy --strict src scripts
 
   docs-coverage:
     name: Docstring coverage (interrogate)
@@ -159,7 +185,7 @@ jobs:
       - name: Check docstring coverage
         run: >-
           uv run --with interrogate interrogate -vv --fail-under 100
-          --ignore-init-method --ignore-magic src tests
+          --ignore-init-method --ignore-magic src tests scripts
 
   deptry:
     name: Dependency hygiene (deptry)
@@ -199,7 +225,7 @@ jobs:
       # narrow and each carries its reason in the line above it: a fixed argument list
       # with no shell is not the injection risk B404/B603 screen for.
       - name: Scan src for insecure patterns
-        run: uvx bandit -r src -ll -q
+        run: uvx bandit -r src scripts -ll -q
 
   audit:
     name: pip-audit (dependency CVEs)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,164 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this package is
+
+`pytest-rhiza` ships the [rhiza](https://github.com/jebel-quant/rhiza) repository checks as
+an installed pytest plugin, replacing the seven files the template used to sync into every
+consumer repo as `.rhiza/tests/`. The checks are parameterised by only two things — the
+repository root and the source folder — so distributing them as a dependency removes the
+synced files, the `pythonpath` entry, the interrogate path, the spelled-out `--with` flags
+and the template's self-tests from every consumer.
+
+It is a runtime dependency of every rhiza-managed repo's test environment. That is the
+reason for two constraints that otherwise look like over-caution: the dependency list is
+held to three small packages (`pytest`, `pytest-timeout`, `packaging`), and the `audit` and
+`license` gates matter more here than usual, because anything entering this closure
+propagates into every consumer.
+
+## Commands
+
+There is **no Makefile** — removed deliberately in #52 — and nothing here invokes
+`rhiza-task`. `.github/workflows/ci.yml` is the definition of every gate; `README.md` under
+"Running one by hand" carries a copy, and `tests/test_readme_gates.py` pins the two together
+in both directions. **Edit a gate's command line in `ci.yml` and the suite fails until the
+README matches.**
+
+Day-to-day loop:
+
+```bash
+uv sync
+uv run pytest                                   # whole suite
+uv run pytest tests/test_fences.py              # one file
+uv run pytest tests/test_fences.py::test_name   # one test
+uvx prek install                                # wire the formatting hooks
+```
+
+The gates have a local entry point again as of #66 — **prefer it over retyping a command
+line**, because it executes the README fence rather than a copy of it:
+
+```bash
+python scripts/gates.py              # every gate except the destructive ones
+python scripts/gates.py lint test    # just these
+python scripts/gates.py --list       # what is defined, without running anything
+```
+
+`scripts/gates.py` holds no recipes. It parses the fence under *Running one by hand* in
+`README.md` and runs what it finds, and it shares that parser with
+`tests/test_readme_gates.py` — so the test's proof that the README equals `ci.yml` is what
+makes running the runner equivalent to running CI. Adding a gate means editing `ci.yml` and
+the README fence; the runner picks it up with no change.
+
+Two gates have side effects worth knowing before running them:
+
+- `lowest-deps` (`uv sync --resolution lowest-direct`) **rewrites `uv.lock`'s resolution in
+  your working tree**. Run plain `uv sync` afterwards to get back. The runner excludes it
+  from a bare run for that reason; naming it (or `--all`) is the opt-in.
+- `rhiza-test` runs this package's own checks against this repository. CI wraps the pytest
+  call in a `grep` guard that fails the job if any check *skips*, and checks out with
+  `fetch-depth: 0` so the tag-comparing assertions have tags to compare (#34). The README's
+  copy stops at the pytest invocation, because the guard is a property of the pipeline —
+  `scripts/gates.py` carries the guard, so a local pass means what CI's does.
+
+Thresholds are deliberately single-homed: the 100% docstring floor, the 90% coverage floor
+and `mypy`'s `--strict` all live on their CI command lines and are **not** mirrored into
+`pyproject.toml`, so there is one place to change each. There is no `[tool.mypy]` table and
+adding one would create a second home.
+
+**Type checking runs two checkers** (#67), over `src` and `scripts` but never `tests/`.
+`ty` is fast inference; `mypy --strict` additionally demands annotations, which `ty` has no
+opinion on — on adoption it found 61 errors in code `ty` passed clean, including a real
+disagreement where `bumpversion_table` returned a non-table that `has_bumpversion_section`
+called absent. Keep both: dropping `ty` loses speed, dropping `mypy` loses the annotation
+floor that keeps `Any` from spreading back in.
+
+## Architecture
+
+**Two halves, because pytest treats them differently.**
+
+*Fixtures* arrive through the `pytest11` entry point (`plugin.py`), so a consumer needs no
+`conftest.py`: `root` (the repository under test), `logger`, `latest_tag` (newest `vX.Y.Z`,
+skipping when there are none).
+
+*Checks* are tests, which an entry point cannot contribute, so they are named explicitly:
+`pytest --pyargs pytest_rhiza.checks.test_readme …`. One module per file the template used
+to sync, **names unchanged**. Selection is a property of the consumer's declared layer set
+(`[tool.rhiza-task] layers`), never sniffed from its manifest at runtime — a misconfigured
+repo should go red, not quietly run a different check set.
+
+### Root resolution is the one behaviour change from the synced suite
+
+`.rhiza/tests/conftest.py` counted directories up from `__file__`, which was sound while
+the code lived in the repository and is wrong once installed. `_resolve_root` is now a
+three-rung ladder: `--rhiza-root`, then the config file's directory, then **the invocation
+directory** — not `config.rootpath`, because with no config file pytest derives rootdir
+from the arguments, and under `--pyargs` those point into site-packages.
+
+### Private helpers exist because one distribution is the shared home
+
+`_fences`, `_bumpversion`, `_versions`, `_source_folder`, `_process` hold logic that
+upstream was **duplicated across bundles** — a Rust project received one file and not the
+other, so a shared helper would have needed a third home both bundles shipped. One
+distribution *is* that third home, so the trade reversed. Each module's docstring records
+the specific reason; read it before folding one back into a check.
+
+`_toml` is the exception to that story: it holds one type alias, `TomlTable`, and exists
+so the reason TOML values are `Any` is written once instead of implied at forty call sites.
+
+Two of them encode non-obvious decisions:
+
+- `_process` gives every child process an explicit timeout. `pytest-timeout` cannot do this
+  job: it takes its bound from the **consumer's** ini setting, and nothing here sets a
+  default — this repo's own `timeout = 60` is exactly why the gap was invisible (#44).
+- `_versions` asserts the declared version is *not behind* the newest tag rather than equal
+  to it, because `/rhiza:release` is two-phase: phase A bumps the version on a PR, phase B
+  tags the merged commit, and equality cannot hold in between (#62).
+
+## Testing model
+
+Two harnesses, and the distinction matters when adding tests (`tests/conftest.py` documents
+it in full):
+
+- **`pytester`** — runs pytest inside pytest, in-process. The honest way to test *fixtures*
+  whose job is answering "which repository is this".
+- **`subject`** — builds a throwaway git repository and runs the real
+  `--pyargs … --rhiza-root …` command line against it **in a subprocess**. This is the only
+  way to test the *checks*, because that is the code path every consumer uses; `pytester`
+  drives a different one.
+
+Consequence: coverage of `src/pytest_rhiza/checks/` comes entirely from those subprocesses,
+which is why `[tool.coverage.run] patch = ["subprocess"]` is set. Without it that whole
+directory reads as 0% however well tested it is.
+
+Most subjects need to be a git repo with a tag — the version checks compare a manifest
+against tag state, and with no repository they *skip*, which reads as a pass. That failure
+mode (#34) is the one this suite is most careful about.
+
+## Conventions with teeth
+
+- **Source modules under `checks/` are named `test_*.py` on purpose** — they are collected
+  out of site-packages by name, so that *is* the published interface. Test-layout mirroring
+  is therefore opted out of in `[tool.check_test_layout]` with a recorded reason; tests are
+  organised by behaviour in `tests/` instead.
+- **Docstring coverage is 100% over `src` *and* `tests`** — a test whose name is its only
+  explanation is what that bar exists to prevent. Docstrings here carry real doctests (84 of
+  them); `_resolve_root` documents its ladder by example precisely because a fixture needs a
+  live session to exercise.
+- **Version numbers live in exactly two places**, kept in step by
+  `[[tool.bumpversion.files]]`: `[project].version` (read natively) and
+  `pytest_rhiza.__version__`. `tests/test_version.py` asserts both that they agree and that
+  the bumpversion entry still exists. It sat three releases stale when that entry was
+  described in a comment but never written (#12).
+- **No version literal in `README.md`.** The documented pin is a `<version>` placeholder;
+  nothing bumps a number written there, so it rotted at `0.1.0` for three releases (#17).
+  `tests/test_readme_pin.py` keeps a literal from creeping back.
+- **Nothing here invokes `jebel-quant/rhiza`.** That repo pins pytest-rhiza as a dependency,
+  so calling its reusable CI would close a cycle — rhiza's workflow running the gates that
+  judge the package rhiza depends on. `rhiza_release.yml` is the one exception, synced
+  verbatim because PyPI Trusted Publishing validates the exact workflow path.
+- **The `pytest>=8.1` floor is bisected, not guessed.** 8.0.x walks the generic ancestor
+  chain of a `--pyargs` argument and dies on an unstat-able `/home` entry on GitHub runners
+  (#23). The `lowest-deps` gate is what stops that floor rotting.
+- **Third-party actions are SHA-pinned** with the version in a trailing comment, kept moving
+  by `.github/dependabot.yml`.

--- a/README.md
+++ b/README.md
@@ -203,10 +203,10 @@ what it is.
 | --- | --- |
 | `lint` | `uvx prek run --all-files` — every hook in `.pre-commit-config.yaml` |
 | `test` | the suite on 3 OSes × 4 Python versions, at a 90% coverage floor |
-| `typecheck` | `ty check src` |
-| `docs-coverage` | interrogate over `src` and `tests`, at a 100% floor |
+| `typecheck` | `ty check src scripts`, then `mypy --strict src scripts` |
+| `docs-coverage` | interrogate over `src`, `tests` and `scripts`, at a 100% floor |
 | `deptry` | declared-vs-imported deps, against `[tool.deptry]` in `pyproject.toml` |
-| `security` | bandit over `src`, medium-and-above |
+| `security` | bandit over `src` and `scripts`, medium-and-above |
 | `audit` | `pip-audit` over the locked environment |
 | `lowest-deps` | the suite against `--resolution lowest-direct`, testing the version floors |
 | `license` | refuses strong copyleft in the runtime closure |
@@ -219,13 +219,14 @@ what it is.
 # lint
 uvx prek run --all-files --show-diff-on-failure
 # typecheck
-uv run --with ty ty check src
+uv run --with ty ty check src scripts
+uv run --with mypy mypy --strict src scripts
 # docs-coverage
-uv run --with interrogate interrogate -vv --fail-under 100 --ignore-init-method --ignore-magic src tests
+uv run --with interrogate interrogate -vv --fail-under 100 --ignore-init-method --ignore-magic src tests scripts
 # deptry
 uvx deptry src
 # security
-uvx bandit -r src -ll -q
+uvx bandit -r src scripts -ll -q
 # audit
 uvx pip-audit
 # license
@@ -255,6 +256,28 @@ run `uv sync` afterwards to get back. And `rhiza-test`'s line stops at the pytes
 invocation: CI wraps it in a `grep` guard that fails the job if any check *skips* (#34),
 which is a property of the pipeline rather than of the gate.
 
+#### Running all of them
+
+```bash
+python scripts/gates.py              # every gate except the destructive ones
+python scripts/gates.py lint test    # just these
+python scripts/gates.py --list       # what is defined, without running anything
+```
+
+`scripts/gates.py` **runs the block above rather than restating it** (#66), which is what
+keeps it from being the second home #52 removed: it parses that fence and executes what it
+finds, so `ci.yml` is still the only place a gate command line is written. The runner and
+`tests/test_readme_gates.py` share the parser deliberately — if the runner read this file
+its own way, that test would pin a parse of the README that nothing actually executes.
+
+It also closes the two gaps above, which is most of why it is worth having. `lowest-deps` is
+excluded from a bare run and needs naming (or `--all`), because rewriting your lockfile
+should be something you asked for; and `rhiza-test` carries the `grep` guard, so a local
+pass means what CI's does instead of going green on `32 passed, 2 skipped`.
+
+Every selected gate runs even after one fails, and the summary at the end is the whole
+picture — the same reason `ci-gate` aggregates rather than the jobs depending on each other.
+
 `weekly.yml` carries the two that are too slow or noisy for every push: a fresh
 dependency resolution, and a link check over this file.
 
@@ -277,10 +300,17 @@ Publishing validates the exact workflow path. The `rhiza_codeql.yml` and
 Scorecard workflows, a pinned edge to keep current for scanning this repository does not
 depend on.
 
-The cost of dropping the Makefile is real and worth stating: **no gate has a local entry
-point any more** (#49, #32). That was the call made in #52 — a Makefile in a repo whose
-ecosystem retired make as an interface is a second thing to keep correct — but it does mean
-the only way to run a gate by hand is to read its command line out of `ci.yml`.
+The cost of dropping the Makefile was real and was stated plainly here for three releases:
+**no gate had a local entry point at all** (#49, #32). That was the call made in #52 — a
+Makefile in a repo whose ecosystem retired make as an interface is a second thing to keep
+correct — and it meant the only way to run a gate by hand was to read its command line out
+of `ci.yml`, which #58 improved to a copy-paste out of this file.
+
+`scripts/gates.py` closes it (#66) without giving any threshold a second home, because it
+holds no recipes: it executes the fence above, which `tests/test_readme_gates.py` already
+pins to `ci.yml`. That is the distinction #52 was actually protecting — not "no runner", but
+no *second copy* of what to run. There is still no `Makefile`, and nothing here invokes
+`rhiza-task`.
 
 ### The checks, self-applied
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,8 @@
 [pytest]
 testpaths = tests
+# So tests/test_readme_gates.py can import scripts.gates, which owns the README
+# fence parser they share (#66). Nothing under scripts/ ships in the wheel.
+pythonpath = .
 addopts = -ra
 timeout = 60
 log_cli = false

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,9 @@
+"""Repo-local developer tooling, deliberately outside the distribution.
+
+Nothing here ships in the wheel. ``[tool.hatch.build.targets.wheel]`` packages
+``src/pytest_rhiza`` only, which is the point: this package is installed into every
+rhiza-managed repo's test environment, and a gate runner is of no use there.
+
+It is a package rather than a loose script folder so ``tests/test_readme_gates.py`` can
+import :mod:`scripts.gates` by name — see ``pythonpath = .`` in ``pytest.ini``.
+"""

--- a/scripts/gates.py
+++ b/scripts/gates.py
@@ -1,0 +1,231 @@
+"""Run the gates locally, by executing the README block rather than restating it.
+
+Issue #66. #52 removed the Makefile and made ``.github/workflows/ci.yml`` the single
+definition of every gate command line, on the grounds that a second home is a second thing
+to keep correct. The cost — recorded in that file's header, in #49 and in #32 — was that no
+gate had a local entry point at all: reproducing a red job meant reading YAML, and after
+#58 it meant eleven copy-pastes out of ``README.md``.
+
+**Why this does not reopen #52.** A runner that held its own copy of the recipes would
+recreate exactly the duplication #52 removed, and this one holds none. It reads the fenced
+block under *Running one by hand* in ``README.md`` and runs what is written there, so the
+only thing added is a way to *execute* a list that already existed. ``ci.yml`` stays the
+definition; the README stays a copy; ``tests/test_readme_gates.py`` still pins the two
+token for token in both directions, which is what makes running the README equivalent to
+running CI.
+
+That test and this module share :func:`documented_gates` for the same reason. If the runner
+parsed the block its own way, the test's guarantee would cover the README rather than the
+thing actually executed — the parser has to be the same one for the chain to hold.
+
+**The two gates that are not a plain copy**, both already flagged in the README:
+
+* ``lowest-deps`` rewrites ``uv.lock``'s resolution in the working tree, so it is excluded
+  from a bare run and reported as skipped. Naming it, or ``--all``, is the opt-in.
+* ``rhiza-test``'s documented line stops at the pytest invocation. CI wraps it in a guard
+  that fails the job when any check *skips*, because a skipped assertion reads as a pass
+  (#34) — :data:`SKIP_GUARD` carries that guard here, so a local pass means what CI's does.
+
+Usage::
+
+    python scripts/gates.py                  # every gate except the destructive ones
+    python scripts/gates.py lint typecheck   # just these
+    python scripts/gates.py --all            # including lowest-deps
+    python scripts/gates.py --list           # what is defined, without running anything
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shlex
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+
+# The same pattern `tests/test_readme_gates.py` used before it imported this module: the
+# `# <gate>` comment lines under the fence, each followed by its command(s).
+_FENCE = re.compile(r"#### Running one by hand\n+```bash\n(.*?)```", re.DOTALL)
+
+#: Gates excluded from a bare run because they change the working tree, mapped to what
+#: they do to it. The README says the same thing in prose; naming one on the command line
+#: is the opt-in.
+DESTRUCTIVE: dict[str, str] = {
+    "lowest-deps": "rewrites uv.lock's resolution — run `uv sync` afterwards to restore it",
+}
+
+#: Gates whose CI job wraps the documented command in the #34 skip guard. Declared rather
+#: than inferred, so it sits in a diff a reviewer sees — the same reasoning as the
+#: scaffolding allowlists in `tests/test_readme_gates.py`, which is the other side of this
+#: fact: `_TRUNCATE_AT` there cuts the guard off the CI side of the comparison.
+SKIP_GUARD = frozenset({"rhiza-test"})
+
+_SKIPPED_MESSAGE = (
+    "A self-applied check skipped. A skipped assertion reads as a pass, which is the "
+    "defect this guard exists to prevent (#34)."
+)
+
+
+class GatesError(RuntimeError):
+    """The README's gate block is missing or empty, so there is nothing to run."""
+
+
+def documented_gates() -> dict[str, list[str]]:
+    """Return each gate the README documents, mapped to its command lines in order.
+
+    Shared with ``tests/test_readme_gates.py``, which compares the result against
+    ``ci.yml``. One parser, so what that test pins is what this module runs.
+
+    Returns:
+        Gate name to the command lines listed under its ``# <gate>`` comment.
+
+    Raises:
+        GatesError: The fence is absent, which means the README was restructured and
+            both this runner and the pinning test have lost their input.
+    """
+    fence = _FENCE.search(README.read_text(encoding="utf-8"))
+    if fence is None:
+        message = (
+            f"{README} has no '#### Running one by hand' bash fence. It is the local entry "
+            "point for every gate (#58) and the input to both this runner and "
+            "tests/test_readme_gates.py; if it moved or was renamed, update _FENCE here."
+        )
+        raise GatesError(message)
+
+    commands: dict[str, list[str]] = {}
+    gate: str | None = None
+    for line in fence.group(1).splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            gate = stripped.lstrip("#").strip()
+            commands.setdefault(gate, [])
+        elif gate is not None:
+            commands[gate].append(stripped)
+    return commands
+
+
+def _run(command: str, *, capture: bool) -> tuple[int, str]:
+    """Run one documented command line from the repository root.
+
+    Args:
+        command: The line as the README writes it. Split with :func:`shlex.split` and run
+            without a shell, so its quoting is honoured and its metacharacters are not.
+        capture: Whether to collect stdout for a guard to read afterwards. When false the
+            child writes straight through, which is what keeps the slow gates legible.
+
+    Returns:
+        The exit status, and the captured stdout (empty when ``capture`` is false).
+    """
+    argv = shlex.split(command)
+
+    # S603/B603 are suppressed on both calls below for one reason: the argument list comes
+    # from README.md in this repository — reviewed content, and already the trust boundary
+    # `checks/test_readme_validation` executes under — and there is no shell, so nothing in
+    # it is re-interpreted. The reason lives here rather than trailing the directive,
+    # because prose after the code is what ruff reads as a second code.
+    if not capture:
+        finished = subprocess.run(argv, cwd=ROOT, check=False)  # noqa: S603  # nosec B603
+        return finished.returncode, ""
+
+    proc = subprocess.run(  # noqa: S603  # nosec B603
+        argv, cwd=ROOT, check=False, capture_output=True, text=True
+    )
+    sys.stdout.write(proc.stdout)
+    sys.stderr.write(proc.stderr)
+    return proc.returncode, proc.stdout
+
+
+def run_gate(name: str, commands: list[str]) -> bool:
+    """Run every command of one gate, in order, stopping at the first failure.
+
+    Args:
+        name: The gate name, which selects the guard in :data:`SKIP_GUARD`.
+        commands: Its command lines, from :func:`documented_gates`.
+
+    Returns:
+        Whether the gate passed.
+    """
+    guarded = name in SKIP_GUARD
+    for command in commands:
+        print(f"\n\033[1m→ {name}\033[0m: {command}", flush=True)
+        status, stdout = _run(command, capture=guarded)
+        if status != 0:
+            return False
+        if guarded and "skipped" in stdout:
+            print(f"\033[31m{_SKIPPED_MESSAGE}\033[0m")
+            return False
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments, run the selected gates, and report.
+
+    Every selected gate runs even after one fails, so a single pass shows the whole
+    picture rather than stopping at the first red — the same reason ``ci-gate`` aggregates
+    instead of the jobs depending on each other.
+
+    Args:
+        argv: Command-line arguments, defaulting to :data:`sys.argv`.
+
+    Returns:
+        A process exit status: 0 when every selected gate passed, 1 when one failed, 2
+        when the selection itself was wrong.
+    """
+    parser = argparse.ArgumentParser(
+        prog="scripts/gates.py",
+        description=__doc__.split("\n\n")[0] if __doc__ else None,
+    )
+    parser.add_argument("gates", nargs="*", help="gates to run (default: all but the destructive ones)")
+    parser.add_argument("--all", action="store_true", help=f"include {', '.join(sorted(DESTRUCTIVE))}")
+    parser.add_argument("--list", action="store_true", help="list the documented gates and exit")
+    args = parser.parse_args(argv)
+
+    try:
+        documented = documented_gates()
+    except GatesError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    if args.list:
+        for name, commands in documented.items():
+            note = f"  [skipped by default: {DESTRUCTIVE[name]}]" if name in DESTRUCTIVE else ""
+            print(f"{name}{note}")
+            for command in commands:
+                print(f"    {command}")
+        return 0
+
+    unknown = sorted(set(args.gates) - set(documented))
+    if unknown:
+        print(f"error: no such gate: {', '.join(unknown)}", file=sys.stderr)
+        print(f"known gates: {', '.join(documented)}", file=sys.stderr)
+        return 2
+
+    if args.gates:
+        selected = [name for name in documented if name in set(args.gates)]
+    else:
+        selected = [name for name in documented if args.all or name not in DESTRUCTIVE]
+
+    for name in selected:
+        if name in DESTRUCTIVE:
+            print(f"\033[33mnote\033[0m: {name} {DESTRUCTIVE[name]}")
+
+    failed = [name for name in selected if not run_gate(name, documented[name])]
+    skipped = [name for name in documented if name not in selected]
+
+    print("\n\033[1msummary\033[0m")
+    for name in selected:
+        mark = "\033[31mFAIL\033[0m" if name in failed else "\033[32mPASS\033[0m"
+        print(f"  {mark}  {name}")
+    for name in skipped:
+        print(f"  ----  {name} (not selected)")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pytest_rhiza/_bumpversion.py
+++ b/src/pytest_rhiza/_bumpversion.py
@@ -47,6 +47,8 @@ from pathlib import Path, PurePosixPath
 
 import pytest
 
+from pytest_rhiza._toml import TomlTable
+
 # The only filenames bump-my-version auto-discovers (#1453). Rust and Go projects own
 # none of them natively, which is why those bundles ship the first one.
 DISCOVERABLE_CONFIGS = (".bumpversion.toml", ".bumpversion.cfg", "setup.cfg", "pyproject.toml")
@@ -207,8 +209,14 @@ def legacy_config_hint(root: Path) -> str:
     )
 
 
-def bumpversion_table(path: Path) -> dict:
+def bumpversion_table(path: Path) -> TomlTable:
     """Return the ``[tool.bumpversion]`` table from a TOML config file.
+
+    A ``bumpversion`` key that is not itself a table reads as absent. That is the same
+    bar :func:`has_bumpversion_section` applies — it asks ``isinstance(..., dict)`` — and
+    the two disagreed until ``mypy --strict`` was added: this function would hand a
+    ``tool.bumpversion = "yes"`` straight back to callers that then subscript it, while
+    the other reported no config at all.
 
     Args:
         path: A config file known to exist and parse.
@@ -217,10 +225,12 @@ def bumpversion_table(path: Path) -> dict:
         The table, or an empty dict when the file declares none.
     """
     with path.open("rb") as handle:
-        return tomllib.load(handle).get("tool", {}).get("bumpversion", {})
+        data: TomlTable = tomllib.load(handle)
+    table = data.get("tool", {}).get("bumpversion", {})
+    return table if isinstance(table, dict) else {}
 
 
-def assert_release_flow_owns_the_commit_and_the_tag(table: dict) -> None:
+def assert_release_flow_owns_the_commit_and_the_tag(table: TomlTable) -> None:
     """Assert the config leaves committing and tagging to ``/rhiza:release``.
 
     Args:
@@ -279,7 +289,7 @@ class SyncedBumpversionConfig:
         return PurePosixPath(self.version_file).name
 
     @pytest.fixture
-    def bumpversion(self, root: Path) -> dict:
+    def bumpversion(self, root: Path) -> TomlTable:
         """Return the ``[tool.bumpversion]`` table from the synced config.
 
         Args:
@@ -320,7 +330,7 @@ class SyncedBumpversionConfig:
             f"first and wins, so the other config is inert — and being inert, it drifts."
         )
 
-    def test_the_config_does_not_pin_a_current_version(self, bumpversion: dict) -> None:
+    def test_the_config_does_not_pin_a_current_version(self, bumpversion: TomlTable) -> None:
         """``current_version`` must stay absent from a synced config.
 
         The file is owned by rhiza, so a value only the consuming repo can maintain would
@@ -333,7 +343,7 @@ class SyncedBumpversionConfig:
             "/rhiza:update would overwrite it. Omit the key and let the newest tag supply it."
         )
 
-    def test_the_config_targets_the_version_file(self, bumpversion: dict) -> None:
+    def test_the_config_targets_the_version_file(self, bumpversion: TomlTable) -> None:
         """A ``[[files]]`` entry must point at the version file, or nothing is rewritten.
 
         With no entry for it the bump still "succeeds": it reports a new version, and
@@ -345,7 +355,7 @@ class SyncedBumpversionConfig:
             f"{targets}); {self.untargeted_consequence}"
         )
 
-    def test_the_search_is_anchored_to_the_version_declaration(self, bumpversion: dict) -> None:
+    def test_the_search_is_anchored_to_the_version_declaration(self, bumpversion: TomlTable) -> None:
         """The search must be anchored, or it rewrites some other matching version.
 
         ``search``/``replace`` are applied to *every* occurrence in the file, so a bare
@@ -369,6 +379,6 @@ class SyncedBumpversionConfig:
                 f"the {self.version_file_label} entry's search {search!r} {self.unanchored_complaint}"
             )
 
-    def test_the_release_flow_owns_the_commit_and_the_tag(self, bumpversion: dict) -> None:
+    def test_the_release_flow_owns_the_commit_and_the_tag(self, bumpversion: TomlTable) -> None:
         """``/rhiza:release`` folds the changelog into the bump commit and tags it itself."""
         assert_release_flow_owns_the_commit_and_the_tag(bumpversion)

--- a/src/pytest_rhiza/_source_folder.py
+++ b/src/pytest_rhiza/_source_folder.py
@@ -35,6 +35,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from pytest_rhiza._toml import TomlTable
+
 # Read .rhiza/.env at collection time (no environment side-effects).
 RHIZA_ENV_PATH = Path(".rhiza/.env")
 
@@ -110,7 +112,7 @@ def read_rhiza_env(path: Path) -> dict[str, str]:
     return values
 
 
-def doctest_folders(root: Path, values: dict) -> list[Path]:
+def doctest_folders(root: Path, values: TomlTable) -> list[Path]:
     """Return the existing folders whose docstrings should be doctested.
 
     Args:
@@ -178,7 +180,7 @@ def doctest_folders(root: Path, values: dict) -> list[Path]:
     return folders
 
 
-def configured_label(values: dict) -> str:
+def configured_label(values: TomlTable) -> str:
     """Return the folder spec as it was configured, for the skip message.
 
     The skip has to name what was *asked for* rather than what was found — "no doctest

--- a/src/pytest_rhiza/_toml.py
+++ b/src/pytest_rhiza/_toml.py
@@ -1,0 +1,27 @@
+"""The vocabulary type for a parsed TOML table.
+
+**Why this exists rather than forty copies of ``dict[str, Any]``.** Every manifest check
+in this package reads a TOML file and walks the result: ``[project]`` out of
+``pyproject.toml``, ``[package]`` out of ``Cargo.toml``, ``[tool.bumpversion]`` out of
+whichever config file wins. Those tables were annotated as bare ``dict`` until
+``mypy --strict`` was added alongside ``ty``, which is what noticed: bare ``dict`` is
+``dict[Any, Any]``, so it silently erased the one half of the shape that *is* known.
+
+The keys are always ``str`` — TOML has no other key type. The values genuinely are
+``Any``, and that is a property of the format rather than a gap in the annotation: one
+table holds strings, integers, arrays and sub-tables, and a checker that reads
+``project["authors"][0]["name"]`` cannot be told the type of each hop without modelling
+every manifest this package might ever judge.
+
+Naming that once is the point. ``dict[str, Any]`` repeated at forty call sites reads as
+forty separate decisions to give up on typing; one alias says the same thing once, with
+the reason attached.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypeAlias
+
+#: A parsed TOML table: ``str`` keys, heterogeneous values. See the module docstring for
+#: why the values are ``Any`` by nature rather than by omission.
+TomlTable: TypeAlias = dict[str, Any]

--- a/src/pytest_rhiza/checks/test_cargo_toml.py
+++ b/src/pytest_rhiza/checks/test_cargo_toml.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import pytest
 
 from pytest_rhiza._bumpversion import SyncedBumpversionConfig
+from pytest_rhiza._toml import TomlTable
 from pytest_rhiza._versions import assert_declared_version_not_behind_tag
 
 _SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+")
@@ -42,7 +43,7 @@ _REQUIRED_PACKAGE_FIELDS = ("name", "version", "edition", "description")
 
 
 @pytest.fixture(scope="module")
-def cargo_toml(root: Path) -> dict:
+def cargo_toml(root: Path) -> TomlTable:
     """Load and return Cargo.toml as a parsed dict."""
     path = root / "Cargo.toml"
     if not path.exists():
@@ -52,7 +53,7 @@ def cargo_toml(root: Path) -> dict:
 
 
 @pytest.fixture(scope="module")
-def package(cargo_toml: dict) -> dict:
+def package(cargo_toml: TomlTable) -> TomlTable:
     """Return the [package] table, skipping on a virtual workspace manifest.
 
     A workspace root legitimately has no ``[package]`` — it carries only
@@ -84,17 +85,17 @@ class TestPackageFields:
     """Tests for required fields within the [package] table."""
 
     @pytest.mark.parametrize("field", _REQUIRED_PACKAGE_FIELDS)
-    def test_required_field_present(self, package: dict, field: str) -> None:
+    def test_required_field_present(self, package: TomlTable, field: str) -> None:
         """Each required [package] field must be present."""
         assert field in package, f"[package] is missing required field '{field}'"
 
-    def test_name_is_non_empty_string(self, package: dict) -> None:
+    def test_name_is_non_empty_string(self, package: TomlTable) -> None:
         """[package].name must be a non-empty string."""
         name = package.get("name", "")
         assert isinstance(name, str), "[package].name must be a string"
         assert name.strip(), "[package].name must be a non-empty string"
 
-    def test_version_follows_semver(self, package: dict) -> None:
+    def test_version_follows_semver(self, package: TomlTable) -> None:
         """[package].version must follow semver (MAJOR.MINOR.PATCH).
 
         Not merely a convention here: ``.bumpversion.toml``'s ``parse`` regex and its
@@ -108,7 +109,7 @@ class TestPackageFields:
             f"[package].version {version!r} does not follow semver (expected MAJOR.MINOR.PATCH)"
         )
 
-    def test_description_is_non_empty_string(self, package: dict) -> None:
+    def test_description_is_non_empty_string(self, package: TomlTable) -> None:
         """[package].description must be a non-empty string."""
         desc = package.get("description", "")
         if isinstance(desc, dict):
@@ -116,7 +117,7 @@ class TestPackageFields:
         assert isinstance(desc, str), "[package].description must be a string"
         assert desc.strip(), "[package].description must be a non-empty string"
 
-    def test_a_license_is_declared(self, package: dict) -> None:
+    def test_a_license_is_declared(self, package: TomlTable) -> None:
         """[package] must declare `license` or `license-file`.
 
         ``make license`` is ``cargo deny check licenses`` and deny.toml is an
@@ -167,7 +168,7 @@ class TestGitTagVersion:
     ships for every language layer.
     """
 
-    def test_cargo_version_is_not_behind_the_latest_tag(self, latest_tag: str, package: dict) -> None:
+    def test_cargo_version_is_not_behind_the_latest_tag(self, latest_tag: str, package: TomlTable) -> None:
         """[package].version must be the newest vX.Y.Z tag, or ahead of it.
 
         This is the invariant ``.bumpversion.toml`` relies on rather than a style

--- a/src/pytest_rhiza/checks/test_docstrings.py
+++ b/src/pytest_rhiza/checks/test_docstrings.py
@@ -25,16 +25,19 @@ from __future__ import annotations
 import doctest
 import importlib
 import importlib.util
+import logging
 import sys
 import warnings
+from collections.abc import Iterator
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
 from pytest_rhiza._source_folder import RHIZA_ENV_PATH, configured_label, doctest_folders, read_rhiza_env
 
 
-def _iter_modules_from_path(logger, package_path: Path, src_path: Path):
+def _iter_modules_from_path(logger: logging.Logger, package_path: Path, src_path: Path) -> Iterator[ModuleType]:
     """Recursively find all Python modules in a directory."""
     for path in package_path.rglob("*.py"):
         if path.name == "__init__.py":
@@ -53,7 +56,7 @@ def _iter_modules_from_path(logger, package_path: Path, src_path: Path):
             continue
 
 
-def _find_packages(src_path: Path):
+def _find_packages(src_path: Path) -> Iterator[Path]:
     """Find all packages in the source path, including those nested under namespace packages.
 
     Sorted, like :func:`_iter_loose_modules` already sorts its files: ``rglob`` yields in
@@ -68,7 +71,9 @@ def _find_packages(src_path: Path):
             yield package_dir
 
 
-def _evict_shadowing_package(monkeypatch, logger, import_root: Path, package_dir: Path) -> None:
+def _evict_shadowing_package(
+    monkeypatch: pytest.MonkeyPatch, logger: logging.Logger, import_root: Path, package_dir: Path
+) -> None:
     """Drop a same-named package already imported from somewhere other than this folder.
 
     Without this the gate can report a pass having measured code that is not in the tree.
@@ -108,7 +113,7 @@ def _evict_shadowing_package(monkeypatch, logger, import_root: Path, package_dir
         monkeypatch.delitem(sys.modules, cached, raising=False)
 
 
-def _iter_loose_modules(logger, folder: Path):
+def _iter_loose_modules(logger: logging.Logger, folder: Path) -> Iterator[ModuleType]:
     """Import the top-level ``*.py`` files in ``folder`` that are not part of a package.
 
     A folder of standalone scripts (``utils/``, ``scripts/``, ``tools/``) has no
@@ -143,7 +148,9 @@ def _iter_loose_modules(logger, folder: Path):
         yield module
 
 
-def _iter_package_modules(logger, monkeypatch, src_path: Path, import_root: Path):
+def _iter_package_modules(
+    logger: logging.Logger, monkeypatch: pytest.MonkeyPatch, src_path: Path, import_root: Path
+) -> Iterator[ModuleType]:
     """Yield the modules of every package under one configured folder.
 
     Args:
@@ -179,7 +186,9 @@ def _iter_package_modules(logger, monkeypatch, src_path: Path, import_root: Path
         yield from modules
 
 
-def _iter_doctest_modules(logger, monkeypatch, folders: list[Path]):
+def _iter_doctest_modules(
+    logger: logging.Logger, monkeypatch: pytest.MonkeyPatch, folders: list[Path]
+) -> Iterator[ModuleType]:
     """Yield every module to doctest, across folders, packages and loose scripts.
 
     The three-deep walk that used to sit inline in :func:`test_doctests`. Pulling it out
@@ -266,7 +275,7 @@ class _Tally:
         )
 
 
-def _measure(logger, capsys: pytest.CaptureFixture[str], module) -> doctest.TestResults:
+def _measure(logger: logging.Logger, capsys: pytest.CaptureFixture[str], module: ModuleType) -> doctest.TestResults:
     """Run one module's doctests.
 
     Args:
@@ -287,7 +296,12 @@ def _measure(logger, capsys: pytest.CaptureFixture[str], module) -> doctest.Test
         )
 
 
-def _measure_all(logger, capsys: pytest.CaptureFixture[str], monkeypatch, folders: list[Path]) -> _Tally:
+def _measure_all(
+    logger: logging.Logger,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    folders: list[Path],
+) -> _Tally:
     """Doctest every module the folders yield and return the totals.
 
     Args:
@@ -315,7 +329,9 @@ def _measure_all(logger, capsys: pytest.CaptureFixture[str], monkeypatch, folder
     return tally
 
 
-def test_doctests(logger, root, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
+def test_doctests(
+    logger: logging.Logger, root: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     """Run doctests for every module in the configured folders."""
     values = read_rhiza_env(root / RHIZA_ENV_PATH)
     folders = doctest_folders(root, values)

--- a/src/pytest_rhiza/checks/test_pyproject.py
+++ b/src/pytest_rhiza/checks/test_pyproject.py
@@ -35,6 +35,7 @@ from pytest_rhiza._bumpversion import (
     legacy_config_hint,
     shadowing_configs,
 )
+from pytest_rhiza._toml import TomlTable
 from pytest_rhiza._versions import assert_declared_version_not_behind_tag
 
 _SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+")
@@ -42,7 +43,7 @@ _REQUIRED_PROJECT_FIELDS = ("name", "version", "description", "readme", "require
 
 
 @pytest.fixture(scope="module")
-def pyproject(root: Path) -> dict:
+def pyproject(root: Path) -> TomlTable:
     """Load and return pyproject.toml as a parsed dict."""
     path = root / "pyproject.toml"
     if not path.exists():
@@ -52,7 +53,7 @@ def pyproject(root: Path) -> dict:
 
 
 @pytest.fixture(scope="module")
-def project(pyproject: dict) -> dict:
+def project(pyproject: TomlTable) -> TomlTable:
     """Return the [project] table from pyproject.toml."""
     table = pyproject.get("project")
     if not isinstance(table, dict):
@@ -73,7 +74,7 @@ class TestPyprojectToml:
             data = tomllib.load(f)
         assert isinstance(data, dict), "Parsed pyproject.toml must be a TOML table"
 
-    def test_project_table_present(self, pyproject: dict) -> None:
+    def test_project_table_present(self, pyproject: TomlTable) -> None:
         """pyproject.toml must contain a [project] table."""
         assert "project" in pyproject, "pyproject.toml is missing a [project] table"
         assert isinstance(pyproject["project"], dict), "[project] must be a TOML table"
@@ -83,30 +84,30 @@ class TestProjectFields:
     """Tests for required fields within the [project] table."""
 
     @pytest.mark.parametrize("field", _REQUIRED_PROJECT_FIELDS)
-    def test_required_field_present(self, project: dict, field: str) -> None:
+    def test_required_field_present(self, project: TomlTable, field: str) -> None:
         """Each required [project] field must be present."""
         assert field in project, f"[project] is missing required field '{field}'"
 
-    def test_name_is_non_empty_string(self, project: dict) -> None:
+    def test_name_is_non_empty_string(self, project: TomlTable) -> None:
         """[project].name must be a non-empty string."""
         name = project.get("name", "")
         assert isinstance(name, str), "[project].name must be a string"
         assert name.strip(), "[project].name must be a non-empty string"
 
-    def test_version_follows_semver(self, project: dict) -> None:
+    def test_version_follows_semver(self, project: TomlTable) -> None:
         """[project].version must follow semver (MAJOR.MINOR.PATCH)."""
         version = project.get("version", "")
         assert _SEMVER_RE.match(str(version)), (
             f"[project].version {version!r} does not follow semver (expected MAJOR.MINOR.PATCH)"
         )
 
-    def test_requires_python_is_set(self, project: dict) -> None:
+    def test_requires_python_is_set(self, project: TomlTable) -> None:
         """[project].requires-python must be set to a non-empty constraint."""
         rp = project.get("requires-python", "")
         assert isinstance(rp, str), "[project].requires-python must be a string"
         assert rp.strip(), "[project].requires-python must be a non-empty version constraint"
 
-    def test_authors_have_names(self, project: dict) -> None:
+    def test_authors_have_names(self, project: TomlTable) -> None:
         """[project].authors must contain at least one entry with a non-empty 'name'."""
         authors = project.get("authors", [])
         assert isinstance(authors, list), "[project].authors must be a list"
@@ -114,7 +115,7 @@ class TestProjectFields:
         named = [a for a in authors if isinstance(a, dict) and a.get("name", "").strip()]
         assert len(named) >= 1, "At least one entry in [project].authors must have a non-empty 'name'"
 
-    def test_description_is_non_empty_string(self, project: dict) -> None:
+    def test_description_is_non_empty_string(self, project: TomlTable) -> None:
         """[project].description must be a non-empty string."""
         desc = project.get("description", "")
         assert isinstance(desc, str), "[project].description must be a string"
@@ -125,23 +126,23 @@ class TestProjectUrls:
     """Tests for [project.urls] — Homepage and Repository links."""
 
     @pytest.fixture
-    def urls(self, project: dict) -> dict:
+    def urls(self, project: TomlTable) -> TomlTable:
         """Return the [project.urls] table."""
         table = project.get("urls")
         if not isinstance(table, dict):
             pytest.skip("[project.urls] not present")
         return table
 
-    def test_urls_table_present(self, project: dict) -> None:
+    def test_urls_table_present(self, project: TomlTable) -> None:
         """[project.urls] must be present."""
         assert "urls" in project, "pyproject.toml is missing a [project.urls] table"
 
-    def test_homepage_configured(self, urls: dict) -> None:
+    def test_homepage_configured(self, urls: TomlTable) -> None:
         """[project.urls] must include a Homepage entry."""
         assert "Homepage" in urls, "[project.urls] is missing a 'Homepage' entry"
         assert urls["Homepage"].strip(), "[project.urls] 'Homepage' must be non-empty"
 
-    def test_repository_configured(self, urls: dict) -> None:
+    def test_repository_configured(self, urls: TomlTable) -> None:
         """[project.urls] must include a Repository entry."""
         assert "Repository" in urls, "[project.urls] is missing a 'Repository' entry"
         assert urls["Repository"].strip(), "[project.urls] 'Repository' must be non-empty"
@@ -151,12 +152,17 @@ class TestProjectClassifiers:
     """Tests for [project].classifiers — Python version entries."""
 
     @pytest.fixture
-    def classifiers(self, project: dict) -> list[str]:
-        """Return the classifiers list."""
-        cl = project.get("classifiers", [])
-        if not cl:
+    def classifiers(self, project: TomlTable) -> list[str]:
+        """Return the classifiers list.
+
+        Entries are coerced with ``str`` rather than trusted: the assertions below match
+        them against regexes and prefixes, so a manifest declaring a non-string classifier
+        would otherwise fail inside ``re.match`` with a ``TypeError`` instead of a verdict.
+        """
+        declared = project.get("classifiers", [])
+        if not declared:
             pytest.skip("No classifiers declared in [project]")
-        return cl
+        return [str(entry) for entry in declared]
 
     def test_python_version_classifier_present(self, classifiers: list[str]) -> None:
         """At least one 'Programming Language :: Python :: 3.X' classifier must be present."""
@@ -165,7 +171,7 @@ class TestProjectClassifiers:
             "classifiers must include at least one 'Programming Language :: Python :: 3.X' entry"
         )
 
-    def test_no_license_classifier(self, project: dict) -> None:
+    def test_no_license_classifier(self, project: TomlTable) -> None:
         """No deprecated 'License :: ' classifier may be present.
 
         PyPI has deprecated the ``License ::`` trove classifiers in favor of the SPDX
@@ -192,18 +198,18 @@ class TestDependencyGroups:
     """
 
     @pytest.fixture
-    def dependency_groups(self, pyproject: dict) -> dict:
+    def dependency_groups(self, pyproject: TomlTable) -> TomlTable:
         """Return the [dependency-groups] table."""
         dg = pyproject.get("dependency-groups")
         if not isinstance(dg, dict):
             pytest.skip("[dependency-groups] not present")
         return dg
 
-    def test_test_group_present(self, dependency_groups: dict) -> None:
+    def test_test_group_present(self, dependency_groups: TomlTable) -> None:
         """A 'test' dependency group must be declared."""
         assert "test" in dependency_groups, "[dependency-groups] must include a 'test' group"
 
-    def test_test_group_includes_pytest(self, dependency_groups: dict) -> None:
+    def test_test_group_includes_pytest(self, dependency_groups: TomlTable) -> None:
         """The 'test' dependency group must include pytest."""
         test_deps = dependency_groups.get("test", [])
         assert any("pytest" in str(dep).lower() for dep in test_deps), (
@@ -238,14 +244,14 @@ class TestBumpversionConfigIsDiscoverable:
     """
 
     @pytest.fixture
-    def declared_version(self, project: dict) -> str:
+    def declared_version(self, project: TomlTable) -> str:
         """The statically declared project version, or skip when it is dynamic."""
         version = project.get("version")
         if not isinstance(version, str):
             pytest.skip("[project].version is dynamic — no static location to bump")
         return version
 
-    def test_a_discoverable_config_exists(self, root: Path, pyproject: dict, declared_version: str) -> None:
+    def test_a_discoverable_config_exists(self, root: Path, pyproject: TomlTable, declared_version: str) -> None:
         """A bumpversion section must live in a file bump-my-version actually reads."""
         assert discovered_configs(root), (
             f"pyproject.toml declares version {declared_version!r} but no bumpversion config "
@@ -269,7 +275,7 @@ class TestBumpversionConfigIsDiscoverable:
             f"({declared_version!r})"
         )
 
-    def test_config_does_not_duplicate_the_version(self, pyproject: dict, declared_version: str) -> None:
+    def test_config_does_not_duplicate_the_version(self, pyproject: TomlTable, declared_version: str) -> None:
         """``current_version`` is redundant in pyproject.toml, and drifts once stale."""
         section = pyproject.get("tool", {}).get("bumpversion")
         if not isinstance(section, dict):
@@ -282,7 +288,7 @@ class TestBumpversionConfigIsDiscoverable:
             f"[project].version natively."
         )
 
-    def test_the_release_flow_owns_the_commit_and_the_tag(self, pyproject: dict) -> None:
+    def test_the_release_flow_owns_the_commit_and_the_tag(self, pyproject: TomlTable) -> None:
         """``/rhiza:release`` folds the changelog into the bump commit and tags it itself."""
         section = pyproject.get("tool", {}).get("bumpversion")
         if not isinstance(section, dict):
@@ -298,7 +304,7 @@ class TestGitTagVersion:
     layers need it.
     """
 
-    def test_pyproject_version_is_not_behind_the_latest_tag(self, latest_tag: str, project: dict) -> None:
+    def test_pyproject_version_is_not_behind_the_latest_tag(self, latest_tag: str, project: TomlTable) -> None:
         """[project].version must be the newest vX.Y.Z tag, or ahead of it.
 
         Ahead is a release in flight; behind is drift. See

--- a/src/pytest_rhiza/checks/test_readme.py
+++ b/src/pytest_rhiza/checks/test_readme.py
@@ -22,6 +22,7 @@ distribution is that home.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -80,7 +81,7 @@ class TestReadmeBashFragments:
     what this is for; a fence that cannot even parse is a documentation bug regardless.
     """
 
-    def test_bash_blocks_basic_syntax(self, root: Path, logger) -> None:
+    def test_bash_blocks_basic_syntax(self, root: Path, logger: logging.Logger) -> None:
         """Every non-skipped bash block should parse under `bash -n`.
 
         Skips where no working bash exists — see :func:`pytest_rhiza._fences.bash_usable`.

--- a/src/pytest_rhiza/checks/test_readme_validation.py
+++ b/src/pytest_rhiza/checks/test_readme_validation.py
@@ -19,7 +19,9 @@ distribution is that home.
 """
 
 import difflib
+import logging
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -27,7 +29,7 @@ from pytest_rhiza._fences import CODE_BLOCK, RESULT, SKIP_FLAG, should_skip
 from pytest_rhiza._process import execute_timeout, run
 
 
-def _mismatch(code_blocks, result_blocks, expected, actual):
+def _mismatch(code_blocks: list[str], result_blocks: list[str], expected: str, actual: str) -> str:
     """Explain an output mismatch, as the message for the assertion that found it (#46).
 
     The assertion this serves used to carry no message at all, which mattered more here
@@ -64,7 +66,7 @@ def _mismatch(code_blocks, result_blocks, expected, actual):
     )
 
 
-def test_readme_runs(logger, root):
+def test_readme_runs(logger: logging.Logger, root: Path) -> None:
     """Execute README code blocks and compare output to documented results."""
     readme = root / "README.md"
     logger.info("Reading README from %s", readme)
@@ -123,7 +125,7 @@ def test_readme_runs(logger, root):
 class TestReadmeTestEdgeCases:
     """Edge cases for README code block testing."""
 
-    def test_readme_code_is_syntactically_valid(self, root):
+    def test_readme_code_is_syntactically_valid(self, root: Path) -> None:
         """Python code blocks in README should be syntactically valid (skipped blocks are excluded)."""
         readme = root / "README.md"
         content = readme.read_text(encoding="utf-8")

--- a/tests/test_bumpversion.py
+++ b/tests/test_bumpversion.py
@@ -1,0 +1,70 @@
+"""``bumpversion_table`` and ``has_bumpversion_section`` must agree on what counts.
+
+Both answer a question about the same key — ``has_bumpversion_section`` asks whether a file
+declares a usable ``[tool.bumpversion]``, and ``bumpversion_table`` returns it — and until
+``mypy --strict`` was added alongside ``ty`` they disagreed. ``has_bumpversion_section``
+required ``isinstance(..., dict)``; ``bumpversion_table`` returned whatever the key held,
+so a ``tool.bumpversion = "yes"`` was reported as *no config* by one and handed back as a
+string by the other, to callers that immediately subscript it.
+
+Neither checker could have found that on its own: ``ty`` accepted the bare ``dict``
+annotation, and it was ``--strict``'s ``no-any-return`` that made the erased return type
+visible. The narrowing that fixed it is a one-line ternary, which coverage.py cannot see
+into — a conditional expression is a single line, so both outcomes produce the same arc and
+`--cov-branch` reports it fully covered either way. These tests are what actually exercises
+the false side.
+
+:func:`test_a_non_table_declaration_reads_as_absent` is the case that was wrong. The other
+two pin the ordinary answers, so a future simplification back to a bare ``.get`` chain —
+which would look tidier — fails here instead of shipping.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pytest_rhiza._bumpversion import bumpversion_table, has_bumpversion_section
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    """Write a ``pyproject.toml`` holding ``body`` and return its path.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+        body: TOML source.
+
+    Returns:
+        The path written.
+    """
+    path = tmp_path / "pyproject.toml"
+    path.write_text(body, encoding="utf-8", newline="\n")
+    return path
+
+
+def test_a_declared_table_is_returned(tmp_path: Path) -> None:
+    """The ordinary case: the table is handed back, and both functions agree it exists."""
+    path = _write(tmp_path, "[tool.bumpversion]\nallow_dirty = false\ncommit = false\n")
+
+    assert bumpversion_table(path) == {"allow_dirty": False, "commit": False}
+    assert has_bumpversion_section(path)
+
+
+def test_no_declaration_is_an_empty_table(tmp_path: Path) -> None:
+    """A file with no ``[tool.bumpversion]`` yields ``{}`` rather than raising."""
+    path = _write(tmp_path, '[project]\nname = "x"\n')
+
+    assert bumpversion_table(path) == {}
+    assert not has_bumpversion_section(path)
+
+
+def test_a_non_table_declaration_reads_as_absent(tmp_path: Path) -> None:
+    """The disagreement itself: a scalar under that key is not a config to either function.
+
+    Returning the string here would put it in the hands of the ``SyncedBumpversionConfig``
+    assertions, which call ``.get`` on the result — so the failure would have surfaced as an
+    ``AttributeError`` inside a check rather than as the verdict "no bumpversion config".
+    """
+    path = _write(tmp_path, '[tool]\nbumpversion = "yes"\n')
+
+    assert bumpversion_table(path) == {}
+    assert not has_bumpversion_section(path)

--- a/tests/test_gates_runner.py
+++ b/tests/test_gates_runner.py
@@ -1,0 +1,190 @@
+"""The local gate runner: what it selects, and the guard it carries for `rhiza-test`.
+
+Issue #66. ``scripts/gates.py`` exists so a contributor can reproduce a red CI job without
+eleven copy-pastes, and it does that by *executing* the README block rather than holding a
+copy of it. ``tests/test_readme_gates.py`` already proves that block equals ``ci.yml``, and
+the two share :func:`scripts.gates.documented_gates` so the proof transfers — so nothing
+here re-checks the command lines. What is left to test is the runner's own behaviour, which
+that equality says nothing about:
+
+* the fence parser, on input other than this repository's own README — including the
+  restructured-README case, which is the one that silently breaks both consumers;
+* the selection rule, because excluding ``lowest-deps`` by default is the difference
+  between a runner and a footgun: it rewrites ``uv.lock`` in the working tree;
+* the #34 skip guard, which is the one place the runner deliberately does *more* than the
+  README line it runs. CI fails ``rhiza-test`` when any check skips, because a skipped
+  assertion reads as a pass; a local run that reported green on the same output would be
+  worse than no runner at all.
+
+The guard tests drive it with a trivial subprocess that prints the tell-tale word rather
+than with a real check run, because what is under test is the reading of the output, not
+pytest.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.gates import DESTRUCTIVE, GatesError, documented_gates, main, run_gate
+
+# A fence with the two shapes that matter: a gate with one command, one with two, and a
+# destructive gate whose name is in DESTRUCTIVE.
+_FENCE = """
+Some prose.
+
+#### Running one by hand
+
+```bash
+# lint
+uvx prek run --all-files
+# typecheck
+uv run --with ty ty check src
+uv run --with mypy mypy --strict src
+# lowest-deps
+uv sync --resolution lowest-direct
+```
+
+More prose.
+"""
+
+
+def _readme(tmp_path: Path, body: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the runner at a synthetic README.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+        body: Markdown to write.
+        monkeypatch: Used to repoint the module-level ``README`` constant.
+    """
+    path = tmp_path / "README.md"
+    path.write_text(body, encoding="utf-8", newline="\n")
+    monkeypatch.setattr("scripts.gates.README", path)
+
+
+def _script(body: str) -> str:
+    """Return a command line running ``body`` with this interpreter.
+
+    ``sys.executable`` rather than ``python``, because the suite runs on the Windows leg of
+    the matrix too and there is no guarantee which interpreter that name resolves to.
+
+    Args:
+        body: Python source for ``-c``.
+
+    Returns:
+        A command line for :func:`scripts.gates.run_gate`.
+    """
+    return f'"{sys.executable}" -c "{body}"'
+
+
+class TestTheFenceParser:
+    """:func:`documented_gates`, on input other than this repo's own README."""
+
+    def test_gates_map_to_their_commands_in_order(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A gate may carry more than one command, and their order is the run order."""
+        _readme(tmp_path, _FENCE, monkeypatch)
+
+        assert documented_gates() == {
+            "lint": ["uvx prek run --all-files"],
+            "typecheck": ["uv run --with ty ty check src", "uv run --with mypy mypy --strict src"],
+            "lowest-deps": ["uv sync --resolution lowest-direct"],
+        }
+
+    def test_a_missing_fence_is_an_error_naming_the_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A restructured README breaks the runner and the pinning test together.
+
+        Raising beats returning ``{}``: an empty mapping would make the runner report
+        "nothing to do" and exit 0, which reads as a pass.
+        """
+        _readme(tmp_path, "# Title\n\nNo fence here.\n", monkeypatch)
+
+        with pytest.raises(GatesError, match="Running one by hand"):
+            documented_gates()
+
+    def test_this_repos_readme_still_parses(self) -> None:
+        """A vacuity guard on the tests above: the real fence must not be empty."""
+        assert len(documented_gates()) >= 8
+
+
+class TestSelection:
+    """Which gates a bare run picks, and how a wrong name is reported."""
+
+    def test_the_destructive_gate_is_listed_but_flagged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``--list`` shows every gate, and says which one a bare run will leave out."""
+        _readme(tmp_path, _FENCE, monkeypatch)
+
+        assert main(["--list"]) == 0
+
+        out = capsys.readouterr().out
+        assert "lowest-deps" in out
+        assert DESTRUCTIVE["lowest-deps"] in out
+        assert "uvx prek run --all-files" in out
+
+    def test_an_unknown_gate_is_a_usage_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Exit 2, and name the gates that do exist — a typo should not run anything."""
+        _readme(tmp_path, _FENCE, monkeypatch)
+
+        assert main(["typechek"]) == 2
+        assert "no such gate: typechek" in capsys.readouterr().err
+
+    def test_lowest_deps_is_not_run_unless_asked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The whole point of :data:`DESTRUCTIVE`: a bare run must not touch ``uv.lock``.
+
+        Asserted through the summary rather than by watching for a subprocess, because
+        "not selected" is exactly what the user needs to be told.
+        """
+        _readme(
+            tmp_path,
+            "#### Running one by hand\n\n```bash\n# lowest-deps\nuv sync --resolution lowest-direct\n```\n",
+            monkeypatch,
+        )
+
+        assert main([]) == 0
+        assert "lowest-deps (not selected)" in capsys.readouterr().out
+
+
+class TestTheSkipGuard:
+    """`rhiza-test` fails locally on the output CI fails on (#34)."""
+
+    def test_a_skip_fails_the_gate(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """A zero exit status is not enough for a guarded gate."""
+        assert run_gate("rhiza-test", [_script("print('32 passed, 2 skipped')")]) is False
+        assert "reads as a pass" in capsys.readouterr().out
+
+    def test_a_clean_run_passes(self) -> None:
+        """And the guard must not fire on the output this repo actually produces."""
+        assert run_gate("rhiza-test", [_script("print('34 passed in 0.09s')")]) is True
+
+    def test_the_guard_applies_only_where_declared(self) -> None:
+        """`test`'s own output says "skipped" routinely; only `rhiza-test` is guarded."""
+        assert run_gate("test", [_script("print('170 passed, 6 skipped')")]) is True
+
+
+class TestRunningCommands:
+    """The two properties every gate depends on: exit status, and argument splitting."""
+
+    def test_a_nonzero_exit_fails_the_gate(self) -> None:
+        """The ordinary red-gate path."""
+        assert run_gate("lint", [_script("raise SystemExit(1)")]) is False
+
+    def test_later_commands_do_not_run_after_a_failure(self) -> None:
+        """``lowest-deps`` is two commands and the second is meaningless if the first fails."""
+        marker = "second command ran"
+        assert run_gate("lowest-deps", [_script("raise SystemExit(1)"), _script(f"print('{marker}')")]) is False
+
+    def test_quoted_arguments_survive_splitting(self) -> None:
+        """The `license` gate passes one argument holding spaces and semicolons.
+
+        Splitting it on whitespace would hand ``pip-licenses`` a dozen bad arguments, so
+        this pins that the runner uses :func:`shlex.split` and no shell.
+        """
+        check = "import sys; raise SystemExit(0 if sys.argv[1] == 'MIT;MIT License' else 1)"
+        assert run_gate("license", [f'"{sys.executable}" -c "{check}" "MIT;MIT License"']) is True

--- a/tests/test_readme_gates.py
+++ b/tests/test_readme_gates.py
@@ -48,12 +48,10 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
-README = ROOT / "README.md"
-CI = ROOT / ".github" / "workflows" / "ci.yml"
+from scripts.gates import documented_gates
 
-# The fence under "Running one by hand": `# <gate>` lines, each followed by its command(s).
-_FENCE = re.compile(r"#### Running one by hand\n+```bash\n(.*?)```", re.DOTALL)
+ROOT = Path(__file__).resolve().parents[1]
+CI = ROOT / ".github" / "workflows" / "ci.yml"
 
 # A job key: two-space indent, no value. Matched only inside the `jobs:` block, because
 # `on:`'s `push:`/`pull_request:` have the same shape one level up.
@@ -221,28 +219,16 @@ def _ci_jobs() -> dict[str, list[list[str]]]:
 def _documented() -> dict[str, list[str]]:
     """Return each gate documented in the README mapped to its command lines.
 
+    Delegates to :func:`scripts.gates.documented_gates` rather than parsing the fence
+    again, and that is load-bearing rather than tidiness (#66). ``scripts/gates.py``
+    *executes* this block; if it read the README its own way, everything asserted below
+    would pin a parse of the README that nothing actually runs. One parser means the
+    equality proven here — README equals ``ci.yml`` — transfers to the runner.
+
     Returns:
         Gate name to the command lines listed under its ``# <gate>`` comment, in order.
     """
-    fence = _FENCE.search(README.read_text(encoding="utf-8"))
-    assert fence is not None, (
-        "README.md has no '#### Running one by hand' bash fence. It is the local entry "
-        "point for every gate (#58); if it moved or was renamed, update this test — it is "
-        "the only thing keeping those commands in step with ci.yml."
-    )
-
-    commands: dict[str, list[str]] = {}
-    gate: str | None = None
-    for line in fence.group(1).splitlines():
-        stripped = line.strip()
-        if not stripped:
-            continue
-        if stripped.startswith("#"):
-            gate = stripped.lstrip("#").strip()
-            commands.setdefault(gate, [])
-        elif gate is not None:
-            commands[gate].append(stripped)
-    return commands
+    return documented_gates()
 
 
 def _reduced_blocks(gate: str, jobs: dict[str, list[list[str]]]) -> list[list[str]]:


### PR DESCRIPTION
Closes #66. Closes #67.

Both were filed by a `/rhiza:quality` run, and they ship together because each needed the
other's files: the runner is what made `scripts/` a source directory worth type-checking,
and both edit the README fence, `ci.yml` and `CLAUDE.md` in the same regions. Splitting them
would have meant hand-crafting intermediate states of three files.

## #66 — a local entry point that does not reopen #52

`scripts/gates.py` **holds no recipes.** It parses the fence under *Running one by hand* in
`README.md` and runs what is written there, so `ci.yml` stays the only place a gate command
line lives. That is the distinction #52 was actually protecting — not "no runner", but no
*second copy* of what to run. There is still no `Makefile` and nothing here invokes
`rhiza-task`.

```bash
python scripts/gates.py              # every gate except the destructive ones
python scripts/gates.py lint test    # just these
python scripts/gates.py --list       # what is defined, without running anything
```

**The shared parser is load-bearing, not tidiness.** The runner and
`tests/test_readme_gates.py` both use `documented_gates()`. If the runner parsed the fence
its own way, that test would pin a parse of the README that nothing executes; one parser is
what makes the proven equality — README equals `ci.yml` — transfer to the thing actually
run. `tests/test_readme_gates.py` keeps its own `ci.yml` parser and all of the reduction and
allowlist logic; only the README side moved.

Both gaps the README flagged are closed, which is most of why the runner is worth having:

- `lowest-deps` is excluded from a bare run and needs naming (or `--all`), because rewriting
  your lockfile should be something you asked for.
- `rhiza-test` carries the #34 skip guard, so a local pass means what CI's does instead of
  going green on `32 passed, 2 skipped`.

`tests/test_gates_runner.py` (12 tests) covers the parser on synthetic input, the
restructured-README case, the selection rule, and the guard firing.

## #67 — two checkers, because they answer different questions

`ty` infers and reports what it can prove wrong. `mypy --strict` additionally **demands
annotations**, which `ty` has no opinion on. On adoption it found **61 errors across 7 files
that `ty` passed clean**:

| finding | count | what changed |
| --- | --- | --- |
| bare `dict` annotations | 40 | one named `TomlTable` alias in `_toml.py` |
| unannotated functions | 18 | annotated in the docstring and README checks |
| `Any` returned as a concrete type | 2 | narrowed — one was a real defect |

The 40 were `dict[Any, Any]`, silently erasing the known-`str` key type of every parsed TOML
table. `TomlTable` exists so the reason TOML *values* are legitimately `Any` is written once
with its rationale, instead of implied at 40 call sites. The 14 `isinstance(x, dict)` runtime
checks are untouched.

**One finding was a real defect, not a notation gap.** `bumpversion_table` handed back a
non-table `tool.bumpversion` — verified: `bumpversion = "yes"` returned the string `'yes'` —
to callers that immediately subscript it, while `has_bumpversion_section` reported the same
file as having *no config at all*. The two now agree. `tests/test_bumpversion.py` pins it,
and the test is necessary rather than decorative: the fix is a ternary, and coverage.py
cannot see into a conditional expression, so `--cov-branch` reports it fully covered either
way.

Flags stay on the CI command line. **No `[tool.mypy]` table** — same reason the interrogate
threshold and the coverage floor are not mirrored into `pyproject.toml`: one home per
setting.

## Two things beyond the issues, flagged deliberately

1. **`typecheck`, `docs-coverage` and `security` now also cover `scripts/`.** The runner
   introduced a new source directory that no gate touched, and in a repo that gates
   everything else at 100% that is how a blind spot becomes permanent. All three passed with
   no fixes needed.
2. **Claims this change falsified are corrected.** `ci.yml`'s header and the README's *Why no
   Makefile* section both said **no gate has a local entry point any more** (#49, #32). Left
   alone, the repo's most-cited design note would be wrong, so both are rewritten around what
   #52 was protecting. `CLAUDE.md` is new — there was none — and records the same split.

## Verification

All ten gates pass, run through the new runner:

`lint · typecheck · docs-coverage · deptry · security · audit · license · test · rhiza-test`
— plus `lowest-deps` separately, since it rewrites `uv.lock`; restored afterwards and
confirmed byte-identical to `HEAD`.

- **191 tests** (was 176), **100% coverage** against the 90% floor
- `rhiza-test`: **34 passed, 0 skipped**
- **84 doctests** executed in the project environment, 0 failed, 0 unimportable
- README↔CI pin green in both directions
- suite green against the declared floors (`--resolution lowest-direct`, pytest 8.1.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
