### PR TITLE
fix: close the three quality findings from #69-#71

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,10 +115,15 @@ jobs:
       # depends on `[tool.coverage.run] patch = ["subprocess"]` in pyproject.toml: the
       # checks are exercised by inner `pytest --pyargs` runs in subprocesses, which a
       # parent-only coverage run does not see.
+      #
+      # `scripts` is measured beside `src` since #69. Nothing under it ships in the wheel,
+      # which is why it was left out at first — but `scripts/gates.py` is what decides
+      # whether every other gate here is green, and it was the one module held to this
+      # repo's typing and docstring bars with no coverage floor behind them.
       - name: Run tests
         run: >-
           uv run --group test --python ${{ matrix.python-version }}
-          pytest -ra --cov=src --cov-report=term-missing --cov-fail-under=90
+          pytest -ra --cov=src --cov=scripts --cov-report=term-missing --cov-fail-under=90
 
   typecheck:
     name: Type checking (ty + mypy --strict)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,10 @@ the README fence; the runner picks it up with no change.
 Two gates have side effects worth knowing before running them:
 
 - `lowest-deps` (`uv sync --resolution lowest-direct`) **rewrites `uv.lock`'s resolution in
-  your working tree**. Run plain `uv sync` afterwards to get back. The runner excludes it
-  from a bare run for that reason; naming it (or `--all`) is the opt-in.
+  your working tree**. The runner excludes it from a bare run for that reason; naming it (or
+  `--all`) is the opt-in. Since #71 it also re-syncs the lock in a `finally` once the gate
+  finishes, so a red or interrupted run recovers too — run the bare command line by hand and
+  the manual `uv sync` is still yours to remember.
 - `rhiza-test` runs this package's own checks against this repository. CI wraps the pytest
   call in a `grep` guard that fails the job if any check *skips*, and checks out with
   `fetch-depth: 0` so the tag-comparing assertions have tags to compare (#34). The README's
@@ -130,6 +132,11 @@ it in full):
 Consequence: coverage of `src/pytest_rhiza/checks/` comes entirely from those subprocesses,
 which is why `[tool.coverage.run] patch = ["subprocess"]` is set. Without it that whole
 directory reads as 0% however well tested it is.
+
+The floor covers **`scripts` as well as `src`** (#69). Nothing under `scripts/` ships in the
+wheel, so it was outside the measurement at first — but `gates.py` is what decides whether
+every other gate is green, and being typed and interrogated with no coverage behind it left
+its whole selection path unreached.
 
 Most subjects need to be a git repo with a tag — the version checks compare a manifest
 against tag state, and with no repository they *skip*, which reads as a pass. That failure

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ what it is.
 | gate | what it runs |
 | --- | --- |
 | `lint` | `uvx prek run --all-files` — every hook in `.pre-commit-config.yaml` |
-| `test` | the suite on 3 OSes × 4 Python versions, at a 90% coverage floor |
+| `test` | the suite on 3 OSes × 4 Python versions, over `src` and `scripts`, at a 90% floor |
 | `typecheck` | `ty check src scripts`, then `mypy --strict src scripts` |
 | `docs-coverage` | interrogate over `src`, `tests` and `scripts`, at a 100% floor |
 | `deptry` | declared-vs-imported deps, against `[tool.deptry]` in `pyproject.toml` |
@@ -232,7 +232,7 @@ uvx pip-audit
 # license
 uv run --with pip-licenses pip-licenses --allow-only "MIT;MIT License;BSD-2-Clause;BSD-3-Clause;Apache-2.0;Apache-2.0 OR BSD-2-Clause;DFSG approved"
 # test
-uv run --group test pytest -ra --cov=src --cov-report=term-missing --cov-fail-under=90
+uv run --group test pytest -ra --cov=src --cov=scripts --cov-report=term-missing --cov-fail-under=90
 # lowest-deps
 uv sync --all-extras --all-groups --resolution lowest-direct
 uv run --all-extras --all-groups --resolution lowest-direct pytest -ra
@@ -272,8 +272,10 @@ its own way, that test would pin a parse of the README that nothing actually exe
 
 It also closes the two gaps above, which is most of why it is worth having. `lowest-deps` is
 excluded from a bare run and needs naming (or `--all`), because rewriting your lockfile
-should be something you asked for; and `rhiza-test` carries the `grep` guard, so a local
-pass means what CI's does instead of going green on `32 passed, 2 skipped`.
+should be something you asked for — and when the gate finishes the runner re-syncs the lock
+for you, in a `finally`, so a failing or interrupted run recovers too and even `--all` leaves
+`git status` clean (#71). And `rhiza-test` carries the `grep` guard, so a local pass means
+what CI's does instead of going green on `32 passed, 2 skipped`.
 
 Every selected gate runs even after one fails, and the summary at the end is the whole
 picture — the same reason `ci-gate` aggregates rather than the jobs depending on each other.

--- a/scripts/gates.py
+++ b/scripts/gates.py
@@ -54,8 +54,13 @@ _FENCE = re.compile(r"#### Running one by hand\n+```bash\n(.*?)```", re.DOTALL)
 #: they do to it. The README says the same thing in prose; naming one on the command line
 #: is the opt-in.
 DESTRUCTIVE: dict[str, str] = {
-    "lowest-deps": "rewrites uv.lock's resolution — run `uv sync` afterwards to restore it",
+    "lowest-deps": "rewrites uv.lock's resolution — restored with `uv sync` when the gate finishes",
 }
+
+#: Run after a gate in :data:`DESTRUCTIVE` to put the working tree back (#71). Running the
+#: README's command line by hand still needs this done by hand; doing it here is what makes
+#: the destructive gate repeat-safe, so that even ``--all`` leaves ``git status`` clean.
+RESTORE_COMMAND = "uv sync"
 
 #: Gates whose CI job wraps the documented command in the #34 skip guard. Declared rather
 #: than inferred, so it sits in a diff a reviewer sees — the same reasoning as the
@@ -143,23 +148,94 @@ def _run(command: str, *, capture: bool) -> tuple[int, str]:
 def run_gate(name: str, commands: list[str]) -> bool:
     """Run every command of one gate, in order, stopping at the first failure.
 
+    A gate in :data:`DESTRUCTIVE` is followed by :data:`RESTORE_COMMAND`, in a ``finally``
+    so that a gate which fails — or one interrupted part-way — restores the working tree as
+    well (#71). That is the difference between a gate which perturbs the tree while it runs
+    and one which leaves it perturbed.
+
     Args:
-        name: The gate name, which selects the guard in :data:`SKIP_GUARD`.
+        name: The gate name, which selects the guard in :data:`SKIP_GUARD` and the restore
+            in :data:`DESTRUCTIVE`.
         commands: Its command lines, from :func:`documented_gates`.
 
     Returns:
         Whether the gate passed.
     """
     guarded = name in SKIP_GUARD
-    for command in commands:
-        print(f"\n\033[1m→ {name}\033[0m: {command}", flush=True)
-        status, stdout = _run(command, capture=guarded)
-        if status != 0:
-            return False
-        if guarded and "skipped" in stdout:
-            print(f"\033[31m{_SKIPPED_MESSAGE}\033[0m")
-            return False
-    return True
+    try:
+        for command in commands:
+            print(f"\n\033[1m→ {name}\033[0m: {command}", flush=True)
+            status, stdout = _run(command, capture=guarded)
+            if status != 0:
+                return False
+            if guarded and "skipped" in stdout:
+                print(f"\033[31m{_SKIPPED_MESSAGE}\033[0m")
+                return False
+        return True
+    finally:
+        if name in DESTRUCTIVE:
+            print(f"\n\033[1m→ {name}\033[0m: {RESTORE_COMMAND}  [restoring the working tree]", flush=True)
+            _run(RESTORE_COMMAND, capture=False)
+
+
+def _print_listing(documented: dict[str, list[str]]) -> None:
+    """Print every documented gate and its command lines, for ``--list``.
+
+    Args:
+        documented: The mapping from :func:`documented_gates`.
+    """
+    for name, commands in documented.items():
+        note = f"  [skipped by default: {DESTRUCTIVE[name]}]" if name in DESTRUCTIVE else ""
+        print(f"{name}{note}")
+        for command in commands:
+            print(f"    {command}")
+
+
+def select_gates(requested: list[str], documented: dict[str, list[str]], *, include_destructive: bool) -> list[str]:
+    """Resolve which gates to run, in the order the README documents them.
+
+    Args:
+        requested: Gate names from the command line. Empty means the default set.
+        documented: The mapping from :func:`documented_gates`.
+        include_destructive: Whether ``--all`` was given. It only affects the default set —
+            naming a gate in :data:`DESTRUCTIVE` explicitly is itself the opt-in.
+
+    Returns:
+        The selected names, ordered as ``documented`` orders them rather than as they were
+        typed, so a run reads the same way whatever order the arguments arrived in.
+
+    Raises:
+        GatesError: A requested gate is not documented. Raising beats skipping it silently,
+            which would run a smaller set than was asked for and still exit 0.
+    """
+    unknown = sorted(set(requested) - set(documented))
+    if unknown:
+        message = f"no such gate: {', '.join(unknown)}\nknown gates: {', '.join(documented)}"
+        raise GatesError(message)
+
+    if requested:
+        return [name for name in documented if name in set(requested)]
+    return [name for name in documented if include_destructive or name not in DESTRUCTIVE]
+
+
+def _print_summary(selected: list[str], failed: list[str], documented: dict[str, list[str]]) -> None:
+    """Print the per-gate verdict, including the gates this run left out.
+
+    The not-selected lines are the point rather than padding: a summary listing only what
+    ran cannot be told apart from one where a gate was silently dropped.
+
+    Args:
+        selected: The gates that ran, in run order.
+        failed: Those of them that failed.
+        documented: The mapping from :func:`documented_gates`, for the not-selected lines.
+    """
+    print("\n\033[1msummary\033[0m")
+    for name in selected:
+        mark = "\033[31mFAIL\033[0m" if name in failed else "\033[32mPASS\033[0m"
+        print(f"  {mark}  {name}")
+    for name in documented:
+        if name not in selected:
+            print(f"  ----  {name} (not selected)")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -168,6 +244,12 @@ def main(argv: list[str] | None = None) -> int:
     Every selected gate runs even after one fails, so a single pass shows the whole
     picture rather than stopping at the first red — the same reason ``ci-gate`` aggregates
     instead of the jobs depending on each other.
+
+    The work is in :func:`documented_gates`, :func:`select_gates`, :func:`run_gate` and the
+    two printers; what is left here is the argument surface and the exit status. This was
+    one function until #70, where it measured CC 24 — breadth rather than nesting, but the
+    selection path it held was also the part no test reached, which is the more useful thing
+    the split bought.
 
     Args:
         argv: Command-line arguments, defaulting to :data:`sys.argv`.
@@ -185,47 +267,27 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--list", action="store_true", help="list the documented gates and exit")
     args = parser.parse_args(argv)
 
+    # One handler for both failures, because they are the same answer to the user: a README
+    # with no fence leaves nothing to choose from, and a typo names something that does not
+    # exist. Neither ran a gate, so neither is a gate failure — hence 2 rather than 1.
     try:
         documented = documented_gates()
+        if args.list:
+            _print_listing(documented)
+            return 0
+        selected = select_gates(args.gates, documented, include_destructive=args.all)
     except GatesError as error:
         print(f"error: {error}", file=sys.stderr)
         return 2
-
-    if args.list:
-        for name, commands in documented.items():
-            note = f"  [skipped by default: {DESTRUCTIVE[name]}]" if name in DESTRUCTIVE else ""
-            print(f"{name}{note}")
-            for command in commands:
-                print(f"    {command}")
-        return 0
-
-    unknown = sorted(set(args.gates) - set(documented))
-    if unknown:
-        print(f"error: no such gate: {', '.join(unknown)}", file=sys.stderr)
-        print(f"known gates: {', '.join(documented)}", file=sys.stderr)
-        return 2
-
-    if args.gates:
-        selected = [name for name in documented if name in set(args.gates)]
-    else:
-        selected = [name for name in documented if args.all or name not in DESTRUCTIVE]
 
     for name in selected:
         if name in DESTRUCTIVE:
             print(f"\033[33mnote\033[0m: {name} {DESTRUCTIVE[name]}")
 
     failed = [name for name in selected if not run_gate(name, documented[name])]
-    skipped = [name for name in documented if name not in selected]
-
-    print("\n\033[1msummary\033[0m")
-    for name in selected:
-        mark = "\033[31mFAIL\033[0m" if name in failed else "\033[32mPASS\033[0m"
-        print(f"  {mark}  {name}")
-    for name in skipped:
-        print(f"  ----  {name} (not selected)")
-
+    _print_summary(selected, failed, documented)
     return 1 if failed else 0
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - exercised by running the script, not the suite
     sys.exit(main())

--- a/tests/test_gates_runner.py
+++ b/tests/test_gates_runner.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.gates import DESTRUCTIVE, GatesError, documented_gates, main, run_gate
+from scripts.gates import DESTRUCTIVE, GatesError, documented_gates, main, run_gate, select_gates
 
 # A fence with the two shapes that matter: a gate with one command, one with two, and a
 # destructive gate whose name is in DESTRUCTIVE.
@@ -49,6 +49,28 @@ uv sync --resolution lowest-direct
 
 More prose.
 """
+
+
+def _fence_of(gates: dict[str, list[str]]) -> str:
+    """Return a *Running one by hand* fence documenting the given gates.
+
+    The module-level :data:`_FENCE` documents real command lines, which is right for the
+    parser and the selection tests because neither executes anything. Tests that drive
+    :func:`main` all the way through to a run need commands that are safe to execute, and
+    so build their own fence here.
+
+    Args:
+        gates: Gate name to its command lines, in the order they should be written.
+
+    Returns:
+        Markdown holding a fence the parser will find.
+    """
+    lines = ["#### Running one by hand", "", "```bash"]
+    for name, commands in gates.items():
+        lines.append(f"# {name}")
+        lines.extend(commands)
+    lines.append("```")
+    return "\n".join(lines) + "\n"
 
 
 def _readme(tmp_path: Path, body: str, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -79,6 +101,25 @@ def _script(body: str) -> str:
     return f'"{sys.executable}" -c "{body}"'
 
 
+@pytest.fixture
+def stub_restore(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Replace the post-destructive ``uv sync`` with a harmless marker-printing script.
+
+    The restore added in #71 has to be exercised through the real code path rather than
+    asserted from the source, but a suite that genuinely re-resolved ``uv.lock`` would be
+    slow and would rewrite the working tree — the very thing the restore exists to undo.
+
+    Args:
+        monkeypatch: Used to repoint the module-level ``RESTORE_COMMAND``.
+
+    Returns:
+        The marker the stub prints, for the caller to assert on.
+    """
+    marker = "RESTORED"
+    monkeypatch.setattr("scripts.gates.RESTORE_COMMAND", _script(f"print('{marker}')"))
+    return marker
+
+
 class TestTheFenceParser:
     """:func:`documented_gates`, on input other than this repo's own README."""
 
@@ -102,6 +143,21 @@ class TestTheFenceParser:
 
         with pytest.raises(GatesError, match="Running one by hand"):
             documented_gates()
+
+    def test_blank_lines_inside_the_fence_are_skipped(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A blank line separating two gates is layout, not a command.
+
+        Worth pinning because the parser appends any non-comment line to the current gate:
+        without the skip, a gate would carry an empty command line and the runner would
+        hand :func:`shlex.split` nothing to run.
+        """
+        _readme(
+            tmp_path,
+            "#### Running one by hand\n\n```bash\n# lint\nuvx prek run\n\n# audit\nuvx pip-audit\n```\n",
+            monkeypatch,
+        )
+
+        assert documented_gates() == {"lint": ["uvx prek run"], "audit": ["uvx pip-audit"]}
 
     def test_this_repos_readme_still_parses(self) -> None:
         """A vacuity guard on the tests above: the real fence must not be empty."""
@@ -150,6 +206,113 @@ class TestSelection:
         assert main([]) == 0
         assert "lowest-deps (not selected)" in capsys.readouterr().out
 
+    def test_a_missing_fence_is_a_usage_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A restructured README exits 2 through :func:`main`, not just from the parser.
+
+        :class:`TestTheFenceParser` pins that :func:`documented_gates` raises; this pins
+        that the raise becomes a usage exit rather than a traceback, and that the message
+        naming the file survives to stderr.
+        """
+        _readme(tmp_path, "# Title\n\nNo fence here.\n", monkeypatch)
+
+        assert main([]) == 2
+        assert "Running one by hand" in capsys.readouterr().err
+
+    def test_a_named_gate_runs_only_itself(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Naming a gate narrows the run, and the summary says so for the rest."""
+        _readme(
+            tmp_path,
+            _fence_of({"lint": [_script("print('lint ran')")], "audit": [_script("print('audit ran')")]}),
+            monkeypatch,
+        )
+
+        assert main(["lint"]) == 0
+
+        out = capsys.readouterr().out
+        assert "lint ran" in out
+        assert "audit ran" not in out
+        assert "PASS" in out
+        assert "audit (not selected)" in out
+
+    def test_a_failing_gate_is_reported_and_sets_the_exit_status(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Exit 1, a FAIL line for the gate that failed — and the later gate still runs."""
+        _readme(
+            tmp_path,
+            _fence_of({"lint": [_script("raise SystemExit(1)")], "audit": [_script("print('audit ran')")]}),
+            monkeypatch,
+        )
+
+        assert main([]) == 1
+
+        out = capsys.readouterr().out
+        assert "FAIL" in out
+        assert "audit ran" in out, "a red gate must not stop the ones after it"
+
+    def test_all_opts_into_the_destructive_gate(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        stub_restore: str,
+    ) -> None:
+        """``--all`` selects ``lowest-deps``, and warns before running it."""
+        _readme(tmp_path, _fence_of({"lowest-deps": [_script("print('resolved')")]}), monkeypatch)
+
+        assert main(["--all"]) == 0
+
+        out = capsys.readouterr().out
+        assert DESTRUCTIVE["lowest-deps"] in out, "the note has to precede the damage"
+        assert "resolved" in out
+        assert stub_restore in out
+
+    def test_selection_follows_the_readme_order_not_the_command_line(self) -> None:
+        """Two gates named back-to-front still run in documented order.
+
+        A run whose order depended on the argument order would make two invocations that
+        asked for the same thing produce differently ordered output.
+        """
+        documented = {"lint": [], "typecheck": [], "test": []}
+
+        assert select_gates(["test", "lint"], documented, include_destructive=False) == ["lint", "test"]
+
+
+class TestRestoringTheWorkingTree:
+    """A destructive gate puts the tree back when it finishes (#71)."""
+
+    def test_a_destructive_gate_is_followed_by_the_restore(
+        self, capsys: pytest.CaptureFixture[str], stub_restore: str
+    ) -> None:
+        """The plain path: ``lowest-deps`` passes, and the lock is re-synced after it."""
+        assert run_gate("lowest-deps", [_script("print('resolved')")]) is True
+
+        out = capsys.readouterr().out
+        assert "resolved" in out
+        assert stub_restore in out
+
+    def test_the_restore_runs_even_when_the_gate_fails(
+        self, capsys: pytest.CaptureFixture[str], stub_restore: str
+    ) -> None:
+        """The reason it is a ``finally``: a red gate is exactly when the tree is dirty.
+
+        Returning early on failure without restoring would leave the lockfile rewritten in
+        precisely the case the contributor is already busy debugging.
+        """
+        assert run_gate("lowest-deps", [_script("raise SystemExit(1)")]) is False
+        assert stub_restore in capsys.readouterr().out
+
+    def test_a_harmless_gate_is_not_followed_by_a_restore(
+        self, capsys: pytest.CaptureFixture[str], stub_restore: str
+    ) -> None:
+        """Only :data:`DESTRUCTIVE` gates are restored — the rest must not pay for it."""
+        assert run_gate("lint", [_script("print('linted')")]) is True
+        assert stub_restore not in capsys.readouterr().out
+
 
 class TestTheSkipGuard:
     """`rhiza-test` fails locally on the output CI fails on (#34)."""
@@ -175,10 +338,17 @@ class TestRunningCommands:
         """The ordinary red-gate path."""
         assert run_gate("lint", [_script("raise SystemExit(1)")]) is False
 
-    def test_later_commands_do_not_run_after_a_failure(self) -> None:
-        """``lowest-deps`` is two commands and the second is meaningless if the first fails."""
+    def test_later_commands_do_not_run_after_a_failure(
+        self, capsys: pytest.CaptureFixture[str], stub_restore: str
+    ) -> None:
+        """``lowest-deps`` is two commands and the second is meaningless if the first fails.
+
+        It takes ``stub_restore`` because the gate it names is destructive: since #71 a real
+        run would re-resolve this repository's own lockfile mid-suite.
+        """
         marker = "second command ran"
         assert run_gate("lowest-deps", [_script("raise SystemExit(1)"), _script(f"print('{marker}')")]) is False
+        assert marker not in capsys.readouterr().out
 
     def test_quoted_arguments_survive_splitting(self) -> None:
         """The `license` gate passes one argument holding spaces and semicolons.


### PR DESCRIPTION
Closes #69, closes #70, closes #71 — the three findings from a `/rhiza:quality` run.

All three land on `scripts/gates.py`, and that is the point rather than a coincidence.
It was the one module held to this repo's typing and docstring bars with no coverage
floor behind it: nothing under `scripts/` ships in the wheel, which is why it sat
outside `--cov=src`, but it is what decides whether every other gate is green. The
block that measured worst for complexity was also the block nothing reached.

## #69 — the `test` gate measures `scripts` beside `src`

`--cov=scripts` added to the `test` line in **both** homes, so
`tests/test_readme_gates.py` still pins `ci.yml` and the README fence token for token.

The gap was not just unmeasured, it was real: the ten uncovered lines were the runner's
whole selection-and-report path — named-gate selection, the destructive-gate note, the
PASS/FAIL summary, `main`'s parse-failure exit — plus the parser's blank-line skip. Those
are now tested rather than only measured.

**191 → 200 tests, 100% of 770 statements** against the 90% floor.

`if __name__ == "__main__":` carries `# pragma: no cover`: it cannot be reached by an
in-process suite, so it is an honest exclusion rather than a covered line.

## #70 — `main` was CC D (24), the repo's only block below B

Split into `_print_listing`, `select_gates` and `_print_summary`. `main` is now **B (9)**,
nothing in `src` or `scripts` ranks below B, and the repo-wide average is unchanged at
**A (3.07)**.

The complexity was breadth, not nesting, so the split is mostly mechanical — with one
substantive consequence that fell out of it: the missing-fence and unknown-gate paths are
now a single `except GatesError`. Both mean the selection itself was wrong and neither ran
a gate, which is exactly why both exit 2 rather than 1. Output is unchanged.

## #71 — `lowest-deps` puts the lockfile back

A gate in `DESTRUCTIVE` is now followed by `RESTORE_COMMAND` in a `finally`, so a red or
interrupted run restores the tree as well. That is the case worth covering: a failing
`lowest-deps` is precisely when the lockfile is rewritten and the contributor is already
busy debugging something else.

Verified by running it rather than by unit test alone — `lowest-deps` downgraded to
pytest 8.1.1, and `git hash-object uv.lock` came back byte-identical afterwards, with no
lockfile entry in `git status`.

Running the README's bare command line by hand still needs a manual `uv sync`; the runner
is what makes the gate repeat-safe, and the docs now say so in those terms.

## One existing test changed

`test_later_commands_do_not_run_after_a_failure` calls `run_gate("lowest-deps", …)`, so
after #71 it would have re-resolved this repository's real lockfile mid-suite. It now takes
a `stub_restore` fixture that repoints `RESTORE_COMMAND` at a harmless script — keeping the
restore path exercised by the real code, without the suite doing the very thing the restore
exists to undo.

## Docs updated with the behaviour

The `ci.yml` threshold comment, the README gate table and runner section, and two
`CLAUDE.md` passages that still told the reader to run `uv sync` afterwards by hand.

## Verification

Every gate green locally via `python scripts/gates.py`: `lint`, `typecheck`,
`docs-coverage`, `deptry`, `security`, `audit`, `license`, `test`, `rhiza-test` — and
`lowest-deps` green on its own run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
