### PR TITLE
fix: close the four quality findings from #73-#76

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,13 @@
 version: 2
 updates:
   # Python dependencies using uv
+  #
+  # The major-version ignore is kept *here* and dropped from github-actions below (#75),
+  # because the two ecosystems fail differently. The runtime constraints in pyproject.toml
+  # are deliberately loose floors (`pytest>=8.1`), so a new major needs no manifest edit to
+  # be picked up, and `weekly.yml`'s `dep-compat` job resolves with `--upgrade --no-locked`
+  # every Monday specifically to catch one that breaks this package. Actions have neither
+  # property: a SHA pin is exact, and nothing else re-resolves it.
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
@@ -42,6 +49,16 @@ updates:
       include: "scope"
 
   # GitHub Actions
+  #
+  # No `ignore` block here, unlike the `uv` ecosystem above, and the asymmetry is the point
+  # (#75). A SHA pin never moves on its own, so this is the only thing that can move it —
+  # which is what the header means by the pins going stale unnoticed. Suppressing majors
+  # would defer exactly that staleness to the next major boundary: when actions/checkout v8
+  # ships, the v7 SHA would sit here with no PR and no signal.
+  #
+  # The `groups` block below still only groups patch and minor, so a major arrives as its
+  # own PR rather than bundled into a batch nobody reads line by line. That is the right
+  # shape for a major: proposed, but never quietly.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -49,9 +66,6 @@ updates:
       day: "tuesday"
       time: "09:00"
       timezone: "Asia/Dubai"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
     labels:
       - "dependencies"

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,16 @@
+# Rules for the `markdownlint-cli2` hook in .pre-commit-config.yaml (#74).
+#
+# The default rule set, with one rule off. Exclusions are decisions, not omissions — the
+# same convention ruff.toml follows, one rationale per line.
+
+default: true
+
+# MD013 (line-length) is off, not raised. The prose in README.md and CLAUDE.md is written
+# one sentence-clause per line at roughly 90-100 characters, which is a deliberate house
+# style: it keeps a diff on a documentation change readable, since editing one clause
+# touches one line. Raising the limit to 120 to match ruff.toml's setting for *code* would
+# still flag the handful of long link-carrying lines and the wide table rows, so the rule
+# would have to be suppressed inline in the places it is least helpful. The rest of the
+# default set — heading structure, list and fence spacing, link syntax — is what this hook
+# is here for, and none of it depends on line width.
+MD013: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,31 @@ repos:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
+
+  # `check-yaml` above proves ci.yml is well-formed YAML, which is a much weaker statement
+  # than it looks: a `needs:` naming a job that does not exist, an invalid `${{ }}`
+  # expression, a retired runner label and a mistyped `uses:` all parse fine. That matters
+  # here more than in most repositories, because ci.yml *is* the definition of every gate
+  # (CLAUDE.md), and a job that silently never runs reads as green — the `rhiza_weekly.yml`
+  # failure mode weekly.yml's own header describes as "a red job waiting for its first
+  # Monday" (#74).
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.9
+    hooks:
+      - id: actionlint
+
+  # The documentation here is load-bearing rather than decorative: README.md's gate fence is
+  # pinned to ci.yml in both directions by tests/test_readme_gates.py, and scripts/gates.py
+  # *executes* that fence. Structural defects in the file the runner parses are worth
+  # catching in a linter and not in the parser. Rules live in .markdownlint.yaml (#74).
+  #
+  # CHANGELOG.md is excluded because git-cliff generates it from the commit log: its
+  # MD022/MD032 findings are the shape of the template's output, so a hand-fix would be
+  # overwritten by the next release, and the fix belongs in cliff.toml's body template
+  # instead. Regenerating is not currently idempotent — it also introduces an
+  # `## [unreleased]` section — so that is its own change, not a drive-by here.
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.9.2
+    hooks:
+      - id: markdownlint-cli2
+        exclude: ^CHANGELOG\.md$

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ uv sync
 uv run pytest                                   # whole suite
 uv run pytest tests/test_fences.py              # one file
 uv run pytest tests/test_fences.py::test_name   # one test
-uvx prek install                                # wire the formatting hooks
+uvx prek install                                # wire the pre-commit hooks
 ```
 
 The gates have a local entry point again as of #66 — **prefer it over retyping a command
@@ -160,6 +160,11 @@ mode (#34) is the one this suite is most careful about.
 - **No version literal in `README.md`.** The documented pin is a `<version>` placeholder;
   nothing bumps a number written there, so it rotted at `0.1.0` for three releases (#17).
   `tests/test_readme_pin.py` keeps a literal from creeping back.
+- **`src/pytest_rhiza/py.typed` is what makes `mypy --strict` worth anything to a consumer.**
+  Without the PEP 561 marker a type checker must treat the installed package as untyped, so
+  every annotation stops at this repository's edge (#73). `tests/test_py_typed.py` guards it
+  in two directions, because the failure is silent here: the suite runs against an editable
+  install, which finds the marker in `src` whether or not the wheel would ship it.
 - **Nothing here invokes `jebel-quant/rhiza`.** That repo pins pytest-rhiza as a dependency,
   so calling its reusable CI would close a cycle — rhiza's workflow running the gates that
   judge the package rhiza depends on. `rhiza_release.yml` is the one exception, synced

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security policy
+
+## Why this file exists
+
+`pytest-rhiza` is a runtime dependency of every rhiza-managed repository's test environment.
+Anything entering this package's dependency closure propagates into all of them, which is the
+same reason the `audit` and `license` gates run on every push rather than weekly. A private
+route for reporting a vulnerability follows from that: a finding here is a finding in every
+consumer at once, and a public issue is the wrong place to say so first.
+
+## Reporting a vulnerability
+
+Use GitHub's private vulnerability reporting:
+**[open a report](https://github.com/Jebel-Quant/pytest-rhiza/security/advisories/new)**.
+It is private to the maintainers, and it is the preferred route because the discussion, the
+fix and the advisory stay attached to the same record.
+
+Please do **not** open a public issue for a suspected vulnerability. For anything that is not
+a vulnerability — a failing check, a false positive, a gate that misreads a repository —
+a normal [issue](https://github.com/Jebel-Quant/pytest-rhiza/issues) is right and welcome.
+
+Expect an acknowledgement within **7 days**. This is a small project maintained on a
+best-effort basis; if a report goes unanswered past that, please escalate by opening a
+public issue that says a private report is outstanding, without the details.
+
+## Supported versions
+
+Fixes land on the latest release. There are no maintenance branches for older lines: the
+package is small, and consumers pin it as a single version, so the supported version is
+whatever `main` most recently tagged.
+
+| Version | Supported |
+| --- | --- |
+| Latest release | Yes |
+| Anything earlier | No — upgrade |
+
+## What is in scope
+
+The package's own code and its declared dependency closure:
+
+- the checks under `pytest_rhiza.checks` and the fixtures in `pytest_rhiza.plugin`;
+- the private helpers, in particular `_process` (it spawns child processes) and `_fences`
+  (it parses README content that `checks/test_readme_validation` then executes);
+- the three runtime dependencies, and anything they pull in.
+
+Two things are deliberately **not** vulnerabilities in this package:
+
+- **A check executing content from the repository under test.** `test_readme_validation`
+  runs the `python` fences in a consumer's own `README.md`, and `scripts/gates.py` runs the
+  command lines in this repository's. Both are by design and documented where they happen;
+  the trust boundary is the repository's own reviewed content, the same boundary `pytest`
+  itself crosses when it imports a `conftest.py`. A way to cross it *from outside* that
+  content — an injection through a path, an environment variable, or a manifest value — is
+  in scope and worth reporting.
+- **Findings in a consumer repository** that this package's checks report. Those are the
+  checks working.
+
+## What a report is most useful with
+
+The version, the Python version, and a minimal repository layout that reproduces it. The
+suite's `subject` fixture in `tests/conftest.py` builds throwaway repositories for exactly
+this purpose, and a failing case written against it is the fastest possible path to a fix.

--- a/tests/test_py_typed.py
+++ b/tests/test_py_typed.py
@@ -1,0 +1,82 @@
+"""The ``py.typed`` marker is what makes this package's annotations reach a consumer.
+
+Issue #73: ``ci.yml`` runs ``ty check src scripts`` *and* ``mypy --strict src scripts``, and
+``CLAUDE.md`` records that the second was adopted specifically for the annotation floor the
+first has no opinion on. All of that stopped at this repository's own boundary. Under PEP
+561 a type checker must treat an installed package as untyped unless it ships a ``py.typed``
+marker, so a consumer's ``mypy`` saw ``Any`` for the ``root``, ``logger`` and ``latest_tag``
+fixtures — a package holding itself to ``--strict`` while enforcing nothing it could pass on.
+
+**Why this is tested at all**, given that the fix is one empty file: an empty file is exactly
+the kind of thing that gets lost. Nothing imports it, no gate reads it, and deleting it
+changes no behaviour *in this repository* — the suite runs against an editable install, so
+``pytest_rhiza.__file__`` points into ``src`` and the marker is found whether or not it would
+ever be packaged. The failure is silent, lands in the wheel, and shows up as "your types
+don't work" in somebody else's repo.
+
+**Two tests, because there are two ways to lose it**, the same split as
+:mod:`tests.test_version`: one catches the marker going missing, the other catches the
+mechanism that ships it being narrowed.
+
+**Why neither builds a wheel.** Asserting on a built artefact is the most direct statement of
+the invariant, and it was checked that way once by hand — ``uv build --wheel`` puts
+``pytest_rhiza/py.typed`` in the archive at 0 bytes. Doing it per-run would make a fast suite
+shell out to a build backend for one bit of information that
+:func:`test_marker_is_inside_the_packaged_directory` already pins: hatchling ships a
+``packages`` entry whole, so a marker inside one is a marker in the wheel.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PYPROJECT = ROOT / "pyproject.toml"
+
+# Spelled the way the pyproject key does — forward slashes on every platform — because that
+# is what the assertion below compares against.
+MARKER = "src/pytest_rhiza/py.typed"
+
+
+def _wheel_packages() -> list[str]:
+    """Return the directories ``[tool.hatch.build.targets.wheel] packages`` ships.
+
+    Returns:
+        The declared package paths, read at test time so a stale copy cannot be what the
+        assertions compare against.
+    """
+    with PYPROJECT.open("rb") as handle:
+        manifest = tomllib.load(handle)
+
+    packages = manifest["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"]
+    return [str(entry) for entry in packages]
+
+
+def test_marker_exists() -> None:
+    """A ``py.typed`` file must sit beside the package's modules."""
+    assert (ROOT / MARKER).is_file(), (
+        f"{MARKER} is missing, so PEP 561 says every consumer's type checker must treat "
+        f"pytest_rhiza as untyped — the fixtures this package exists to provide come back "
+        f"as Any, however clean `mypy --strict` is here (#73)."
+    )
+
+
+def test_marker_is_inside_the_packaged_directory() -> None:
+    """The marker must lie under a declared ``packages`` entry, which is what ships it.
+
+    hatchling ships a ``packages`` entry as a whole directory, so this is the mechanism that
+    puts the marker in the wheel — and the thing that would quietly stop doing so if the
+    entry were ever narrowed to a module list or moved.
+    """
+    packages = _wheel_packages()
+
+    covered = [entry for entry in packages if MARKER.startswith(f"{entry.rstrip('/')}/")]
+
+    assert covered, (
+        f"{MARKER} is not inside any [tool.hatch.build.targets.wheel] packages entry "
+        f"({packages}), so hatchling will not ship it and the marker is present in the "
+        f"source tree only. The editable install this suite runs against would still find "
+        f"it, which is why nothing else here would notice (#73)."
+    )


### PR DESCRIPTION
Closes #73, closes #74, closes #75, closes #76 — the four findings from the
`/rhiza:quality` run that scored this repo 9.7/10 with all 11 gates green. None
was a defect in shipped behaviour; each was a standard the repo held itself to
without the mechanism that makes it count.

## #73 — the strict annotations never left the repo

`ci.yml` runs `ty check src scripts` *and* `mypy --strict src scripts`, and
CLAUDE.md records that the second was adopted for the annotation floor the first
has no opinion on. Under PEP 561 that all stopped at this repository's edge: an
installed package with no `py.typed` must be treated as untyped, so a consumer's
checker saw `Any` for the `root`, `logger` and `latest_tag` fixtures.

Fixed with one empty file. Verified from the consumer side rather than assumed:

```
$ uv build --wheel && unzip -l dist/*.whl | grep py.typed
        0  pytest_rhiza/py.typed

# installed into a throwaway venv, then type-checked against:
use_it.py:5: note: Revealed type is "str"
Success: no issues found in 1 source file
```

`tests/test_py_typed.py` guards two things, because there are two ways to lose
it: the marker going missing, and the `[tool.hatch.build.targets.wheel]` entry
that ships it being narrowed. Both assertions were checked against a removed
marker so they are not vacuous. The docstring records why neither builds a wheel
per-run, and why the failure is otherwise silent here — the suite runs against an
editable install, which finds the marker in `src` whether or not it is packaged.

## #74 — the lint gate stopped at Python

`check-yaml` proved `ci.yml` parses. That is a weaker statement than it looks for
the file that *is* the definition of every gate: a `needs:` naming a job that
does not exist, an invalid `${{ }}` expression, a retired runner label and a
mistyped `uses:` are all well-formed YAML. And `README.md` is load-bearing —
`tests/test_readme_gates.py` pins its fence to `ci.yml` in both directions and
`scripts/gates.py` *executes* that fence — with nothing checking its structure.

Added `actionlint` v1.7.9 and `markdownlint-cli2` v0.9.2. Both were confirmed to
fail on faults the existing hooks pass:

```
$ # needs: no-such-job injected into weekly.yml
.github/workflows/weekly.yml:48:3: job "link-check" needs job "no-such-job"
  which does not exist in this workflow [job-needs]

$ # heading/list spacing broken in SECURITY.md
SECURITY.md:64 MD022/blanks-around-headings ...
SECURITY.md:65 MD032/blanks-around-lists ...
```

Neither found anything on the existing tree — all three workflows, including the
synced `rhiza_release.yml`, are already actionlint-clean, so no exclusion was
needed there.

Two judgement calls, both recorded where they live:

- **`MD013` is off, not raised.** The prose here is one clause per line at
  roughly 90-100 characters, which keeps a documentation diff readable. Raising
  the limit to 120 to match ruff.toml's setting for *code* would still flag the
  wide table rows and link-carrying lines, so the rule would end up suppressed
  inline exactly where it helps least.
- **`CHANGELOG.md` is excluded.** All ten non-MD013 findings were there, and
  git-cliff generates it, so a hand-fix is overwritten at the next release. The
  real fix is in `cliff.toml`'s body template — `trim = true` eats the blank line
  between release sections — but regenerating is **not currently idempotent**: it
  also introduces an `## [unreleased]` section and an extra `💼 Other` entry
  under 0.2.0. That is its own change, not a drive-by here.

Pinned by tag rather than SHA, matching this file's two existing entries. The SHA
convention in CLAUDE.md is about third-party *actions* in workflows; applying it
to hook repos would have been a rule borrowed from the wrong place.

## #75 — the SHA pins had nothing moving them across a major

`dependabot.yml`'s header says the `github-actions` ecosystem was added because
*"the SHA pins added alongside it would otherwise have gone stale unnoticed"* —
while the block below it suppressed every major. A SHA pin never moves on its
own, so this was the only thing that could move it, and majors were the one case
it would not: when `actions/checkout` v8 ships, the v7 SHA would sit there with
no PR and no signal.

The ignore is dropped for `github-actions` and **kept** for `uv`, and the
asymmetry is now written down. The Python constraints are deliberately loose
floors (`pytest>=8.1`) so a new major needs no manifest edit, and `weekly.yml`'s
`dep-compat` job re-resolves with `--upgrade --no-locked` every Monday to catch
one that breaks the package. Actions have neither property. The `groups` block
still batches patch and minor only, so a major arrives as its own PR rather than
inside a batch nobody reads line by line.

## #76 — no disclosure path

CLAUDE.md's reasoning for the `audit` and `license` gates running on every push
applies just as directly to a reporting channel: this package is a runtime
dependency of every rhiza-managed repo's test environment, so a finding here is a
finding in all of them, and the only available route was a public issue.

`SECURITY.md` adds private reporting, a supported-version statement, and an
explicit scope section. The scope half is the part worth reading: a check
*executing* a repository's own README fences is by design — the same boundary
`pytest` crosses importing a `conftest.py` — while a way to cross it from
*outside* that content, through a path, an environment variable or a manifest
value, is in scope and worth reporting.

## Verification

All 11 gates green via `python scripts/gates.py --all`, which executes the README
fence rather than a copy of it:

```
PASS  lint        PASS  audit
PASS  typecheck   PASS  license
PASS  docs-coverage   PASS  test         (202 passed, coverage 100.00%)
PASS  deptry      PASS  lowest-deps  (uv.lock restored byte-identical)
PASS  security    PASS  rhiza-test   (34 passed, 0 skipped)
```

Test count is 200 → 202 from `tests/test_py_typed.py`; coverage stays at 100%
over `src` and `scripts`, and docstring coverage at 100% over `src`, `tests` and
`scripts`. The bundled checkers still report 84 doctest examples with no
violations and every README fence parsing.

CLAUDE.md gains a `py.typed` bullet under "Conventions with teeth" — the list
would be misleading without it now that the invariant has a test behind it — and
one stale comment is corrected: the hooks are no longer only formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
