### PR TITLE
fix: bring scripts/ inside the doctest gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,14 +355,28 @@ jobs:
         with:
           enable-cache: true
 
-      # RHIZA_DOCTEST_FOLDERS is left unset on purpose — this project's Python *is* under
-      # `src`, which is the variable's own fallback, so setting it would add a second place
-      # to keep the folder name correct.
+      # RHIZA_DOCTEST_FOLDERS names both folders because `scripts` was folded into every
+      # other gate one issue at a time — `ty`/`mypy --strict` in #66, `--cov=scripts` in
+      # #69, interrogate's path list from the start — and this one was missed (#81). The
+      # variable's own fallback is `src` alone, so leaving it unset measured a strictly
+      # smaller tree than the rest: a doctest under `scripts/` would never be executed,
+      # and `test_doctests` *skips* rather than fails when it attempts none, which is the
+      # #34 failure mode of a check with no subject reading as a pass.
+      #
+      # It was previously left unset deliberately, on the grounds that `src` is the
+      # fallback and a second home for the folder name is a second thing to keep correct.
+      # That reasoning predated `scripts/` being in scope at all. The second home is real
+      # and is `GATE_ENV` in `scripts/gates.py`, which sets the same value so that
+      # `python scripts/gates.py rhiza-test` doctests what this job does —
+      # `tests/test_readme_gates.py` compares `run:` blocks only, so it cannot pin an
+      # `env:` block the way it pins a command line.
       #
       # `-rs` prints skip reasons, which is what the guard reads. With tags present these
       # five modules are 34 passed / 0 skipped, so "no skips" is a bar this repo actually
       # meets rather than an aspiration.
       - name: Run this package's checks against this repository
+        env:
+          RHIZA_DOCTEST_FOLDERS: "src scripts"
         run: |
           set -o pipefail
           uv run --group test pytest -ra -rs --pyargs \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,14 @@ Two gates have side effects worth knowing before running them:
   call in a `grep` guard that fails the job if any check *skips*, and checks out with
   `fetch-depth: 0` so the tag-comparing assertions have tags to compare (#34). The README's
   copy stops at the pytest invocation, because the guard is a property of the pipeline —
-  `scripts/gates.py` carries the guard, so a local pass means what CI's does.
+  `scripts/gates.py` carries the guard, so a local pass means what CI's does. Its job also
+  sets `RHIZA_DOCTEST_FOLDERS` to `"src scripts"`, and `GATE_ENV` in `scripts/gates.py`
+  carries that for the same reason (#81): the variable's own fallback is `src` alone, so
+  leaving it unset held `scripts/` to a docstring *presence* bar with nothing running the
+  examples in those docstrings. It cannot live in the README fence — `_run` splits a
+  documented line with `shlex.split` and no shell, so a `KEY=value` prefix would become
+  `argv[0]` — so the value has two homes, and `tests/test_readme_gates.py` pins them
+  together in both directions the way it already pins the README to `ci.yml`.
 
 Thresholds are deliberately single-homed: the 100% docstring floor, the 90% coverage floor
 and `mypy`'s `--strict` all live on their CI command lines and are **not** mirrored into
@@ -149,9 +156,12 @@ mode (#34) is the one this suite is most careful about.
   is therefore opted out of in `[tool.check_test_layout]` with a recorded reason; tests are
   organised by behaviour in `tests/` instead.
 - **Docstring coverage is 100% over `src` *and* `tests`** — a test whose name is its only
-  explanation is what that bar exists to prevent. Docstrings here carry real doctests (84 of
-  them); `_resolve_root` documents its ladder by example precisely because a fixture needs a
-  live session to exercise.
+  explanation is what that bar exists to prevent. Docstrings here carry real doctests (90 of
+  them — 84 under `src`, 6 in `scripts/gates.py`); `_resolve_root` documents its ladder by
+  example precisely because a fixture needs a live session to exercise. The doctest gate
+  walks both folders since #81; before that an example under `scripts/` would have been
+  collected by nothing, and `test_doctests` *skips* rather than fails when it attempts
+  none.
 - **Version numbers live in exactly two places**, kept in step by
   `[[tool.bumpversion.files]]`: `[project].version` (read natively) and
   `pytest_rhiza.__version__`. `tests/test_version.py` asserts both that they agree and that

--- a/scripts/gates.py
+++ b/scripts/gates.py
@@ -25,6 +25,8 @@ thing actually executed — the parser has to be the same one for the chain to h
 * ``rhiza-test``'s documented line stops at the pytest invocation. CI wraps it in a guard
   that fails the job when any check *skips*, because a skipped assertion reads as a pass
   (#34) — :data:`SKIP_GUARD` carries that guard here, so a local pass means what CI's does.
+  Its job also sets ``RHIZA_DOCTEST_FOLDERS``, which decides which folders the doctest
+  sweep walks; :data:`GATE_ENV` carries that for the same reason (#81).
 
 Usage::
 
@@ -37,6 +39,7 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import shlex
 import subprocess  # nosec B404
@@ -67,6 +70,23 @@ RESTORE_COMMAND = "uv sync"
 #: scaffolding allowlists in `tests/test_readme_gates.py`, which is the other side of this
 #: fact: `_TRUNCATE_AT` there cuts the guard off the CI side of the comparison.
 SKIP_GUARD = frozenset({"rhiza-test"})
+
+#: Environment a gate's CI job sets, applied here too so a local run means what CI's does
+#: (#81). Only ``rhiza-test`` needs any: its doctest sweep resolves which folders to walk
+#: from ``RHIZA_DOCTEST_FOLDERS``, whose own fallback is ``src`` alone — a strictly smaller
+#: tree than the three gates that already name ``scripts`` (``ty``/``mypy`` in #66,
+#: ``--cov=scripts`` in #69, and interrogate's path list). Left unset, a doctest written
+#: under ``scripts/`` would never be executed by any gate, and ``test_doctests`` *skips*
+#: rather than fails when it attempts none — a check with no subject reading as a pass,
+#: which is the #34 failure mode this repository is otherwise most careful about.
+#:
+#: Declared rather than inferred, for the same reason as :data:`SKIP_GUARD`: it sits in a
+#: diff a reviewer sees. The value is written twice — here and on the ``rhiza-test`` job in
+#: ``ci.yml`` — because ``tests/test_readme_gates.py`` compares ``run:`` blocks only, so an
+#: ``env:`` block is invisible to the pin that would otherwise keep the two in step.
+GATE_ENV: dict[str, dict[str, str]] = {
+    "rhiza-test": {"RHIZA_DOCTEST_FOLDERS": "src scripts"},
+}
 
 _SKIPPED_MESSAGE = (
     "A self-applied check skipped. A skipped assertion reads as a pass, which is the "
@@ -114,7 +134,7 @@ def documented_gates() -> dict[str, list[str]]:
     return commands
 
 
-def _run(command: str, *, capture: bool) -> tuple[int, str]:
+def _run(command: str, *, capture: bool, env: dict[str, str] | None = None) -> tuple[int, str]:
     """Run one documented command line from the repository root.
 
     Args:
@@ -122,11 +142,15 @@ def _run(command: str, *, capture: bool) -> tuple[int, str]:
             without a shell, so its quoting is honoured and its metacharacters are not.
         capture: Whether to collect stdout for a guard to read afterwards. When false the
             child writes straight through, which is what keeps the slow gates legible.
+        env: Variables to add to this process's environment for the child, from
+            :data:`GATE_ENV`. Overlaid rather than replacing it, because the command needs
+            the ambient ``PATH`` and ``VIRTUAL_ENV`` that ``uv`` reads.
 
     Returns:
         The exit status, and the captured stdout (empty when ``capture`` is false).
     """
     argv = shlex.split(command)
+    child_env = {**os.environ, **env} if env else None
 
     # S603/B603 are suppressed on both calls below for one reason: the argument list comes
     # from README.md in this repository — reviewed content, and already the trust boundary
@@ -134,11 +158,11 @@ def _run(command: str, *, capture: bool) -> tuple[int, str]:
     # it is re-interpreted. The reason lives here rather than trailing the directive,
     # because prose after the code is what ruff reads as a second code.
     if not capture:
-        finished = subprocess.run(argv, cwd=ROOT, check=False)  # noqa: S603  # nosec B603
+        finished = subprocess.run(argv, cwd=ROOT, check=False, env=child_env)  # noqa: S603  # nosec B603
         return finished.returncode, ""
 
     proc = subprocess.run(  # noqa: S603  # nosec B603
-        argv, cwd=ROOT, check=False, capture_output=True, text=True
+        argv, cwd=ROOT, check=False, capture_output=True, text=True, env=child_env
     )
     sys.stdout.write(proc.stdout)
     sys.stderr.write(proc.stderr)
@@ -154,18 +178,19 @@ def run_gate(name: str, commands: list[str]) -> bool:
     and one which leaves it perturbed.
 
     Args:
-        name: The gate name, which selects the guard in :data:`SKIP_GUARD` and the restore
-            in :data:`DESTRUCTIVE`.
+        name: The gate name, which selects the guard in :data:`SKIP_GUARD`, the restore
+            in :data:`DESTRUCTIVE` and the environment in :data:`GATE_ENV`.
         commands: Its command lines, from :func:`documented_gates`.
 
     Returns:
         Whether the gate passed.
     """
     guarded = name in SKIP_GUARD
+    env = GATE_ENV.get(name)
     try:
         for command in commands:
             print(f"\n\033[1m→ {name}\033[0m: {command}", flush=True)
-            status, stdout = _run(command, capture=guarded)
+            status, stdout = _run(command, capture=guarded, env=env)
             if status != 0:
                 return False
             if guarded and "skipped" in stdout:
@@ -207,6 +232,37 @@ def select_gates(requested: list[str], documented: dict[str, list[str]], *, incl
     Raises:
         GatesError: A requested gate is not documented. Raising beats skipping it silently,
             which would run a smaller set than was asked for and still exit 0.
+
+    Examples:
+        Selection is ordered by ``documented`` rather than by the command line, so a run
+        reads the same way whatever order the arguments arrived in:
+
+        >>> documented = {"lint": [], "lowest-deps": [], "test": []}
+        >>> select_gates(["test", "lint"], documented, include_destructive=False)
+        ['lint', 'test']
+
+        A bare run leaves out what :data:`DESTRUCTIVE` names, and ``--all`` puts it back:
+
+        >>> select_gates([], documented, include_destructive=False)
+        ['lint', 'test']
+        >>> select_gates([], documented, include_destructive=True)
+        ['lint', 'lowest-deps', 'test']
+
+        Naming a destructive gate is itself the opt-in, so it runs without ``--all``:
+
+        >>> select_gates(["lowest-deps"], documented, include_destructive=False)
+        ['lowest-deps']
+
+        An undocumented name is an error rather than a silently smaller run. The message
+        is printed rather than left as a traceback, because the exception's qualified name
+        depends on whether the module was imported as ``gates`` or ``scripts.gates``:
+
+        >>> try:
+        ...     select_gates(["nope"], documented, include_destructive=False)
+        ... except GatesError as error:
+        ...     print(error)
+        no such gate: nope
+        known gates: lint, lowest-deps, test
     """
     unknown = sorted(set(requested) - set(documented))
     if unknown:

--- a/tests/test_gates_runner.py
+++ b/tests/test_gates_runner.py
@@ -15,6 +15,10 @@ that equality says nothing about:
   README line it runs. CI fails ``rhiza-test`` when any check skips, because a skipped
   assertion reads as a pass; a local run that reported green on the same output would be
   worse than no runner at all.
+* the environment in :data:`scripts.gates.GATE_ENV`, which is the other place it does more
+  than the README line — the value has to reach the child process, and the ambient
+  environment has to survive being added to (#81). Whether that value is the one ``ci.yml``
+  sets is ``tests/test_readme_gates.py``'s job, not this module's.
 
 The guard tests drive it with a trivial subprocess that prints the tell-tale word rather
 than with a real check run, because what is under test is the reading of the output, not
@@ -28,7 +32,15 @@ from pathlib import Path
 
 import pytest
 
-from scripts.gates import DESTRUCTIVE, GatesError, documented_gates, main, run_gate, select_gates
+from scripts.gates import (
+    DESTRUCTIVE,
+    GATE_ENV,
+    GatesError,
+    documented_gates,
+    main,
+    run_gate,
+    select_gates,
+)
 
 # A fence with the two shapes that matter: a gate with one command, one with two, and a
 # destructive gate whose name is in DESTRUCTIVE.
@@ -358,3 +370,40 @@ class TestRunningCommands:
         """
         check = "import sys; raise SystemExit(0 if sys.argv[1] == 'MIT;MIT License' else 1)"
         assert run_gate("license", [f'"{sys.executable}" -c "{check}" "MIT;MIT License"']) is True
+
+
+class TestTheGateEnvironment:
+    """The declared variables must reach the child, without displacing the ambient ones."""
+
+    def test_a_declared_variable_reaches_the_child(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """The whole point: `rhiza-test` runs with the folder list CI gives it (#81)."""
+        body = "import os; print(os.environ.get('RHIZA_DOCTEST_FOLDERS', 'unset'))"
+        assert run_gate("rhiza-test", [_script(body)]) is True
+        assert GATE_ENV["rhiza-test"]["RHIZA_DOCTEST_FOLDERS"] in capsys.readouterr().out
+
+    def test_an_undeclared_gate_gets_no_extra_environment(self, capfd: pytest.CaptureFixture[str]) -> None:
+        """Only `rhiza-test` is declared; `lint` must not inherit its folder list.
+
+        Asserted because the mapping is keyed by gate: a lookup that fell back to "all of
+        it" would leak a doctest folder list into gates that have nothing to do with
+        doctests, and nothing else here would notice.
+
+        ``capfd`` rather than ``capsys``, unlike its neighbours: `lint` is not in
+        :data:`scripts.gates.SKIP_GUARD`, so its child is run uncaptured and writes to the
+        file descriptor directly — which is the point of that branch, and invisible to a
+        fixture that only sees ``sys.stdout``.
+        """
+        body = "import os; print('FOLDERS=' + os.environ.get('RHIZA_DOCTEST_FOLDERS', 'unset'))"
+        assert run_gate("lint", [_script(body)]) is True
+        assert "FOLDERS=unset" in capfd.readouterr().out
+
+    def test_the_ambient_environment_survives(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Overlaid on `os.environ`, not substituted for it.
+
+        `subprocess.run(env=...)` *replaces* the environment rather than extending it, so
+        passing the declared mapping alone would strip `PATH` and `VIRTUAL_ENV` — and every
+        gate's command line begins with `uv`, which reads both.
+        """
+        body = "import os; print('PATH=' + str('PATH' in os.environ))"
+        assert run_gate("rhiza-test", [_script(body)]) is True
+        assert "PATH=True" in capsys.readouterr().out

--- a/tests/test_readme_gates.py
+++ b/tests/test_readme_gates.py
@@ -30,6 +30,15 @@ absorbed the same exception invisibly. :class:`TestTheScaffoldAllowlist` stops i
 the other way, by failing when a declared fragment is no longer in `ci.yml` at all — so a
 dead entry cannot sit there quietly widening the tolerance.
 
+**The environment is pinned too, in both directions (#81).** A gate's ``run:`` block is
+not the whole of what CI runs it with: ``rhiza-test`` also carries an ``env:`` block, and
+``RHIZA_DOCTEST_FOLDERS`` there decides which folders the doctest sweep walks. That value
+cannot live in the README fence, because :func:`scripts.gates._run` splits a documented
+line with :func:`shlex.split` and runs it without a shell, so a ``KEY=value`` prefix would
+become ``argv[0]`` rather than an assignment. It therefore has a second home —
+:data:`scripts.gates.GATE_ENV` — and :class:`TestTheGateEnvironment` is what stops the two
+drifting, the same job the command-line comparison does for the README.
+
 **What is still not caught**, stated rather than hidden, as the subsequence gap was:
 
 * The text *inside* ``rhiza-test``'s skip guard, everything after the ``|``. That is
@@ -48,7 +57,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from scripts.gates import documented_gates
+from scripts.gates import GATE_ENV, documented_gates
 
 ROOT = Path(__file__).resolve().parents[1]
 CI = ROOT / ".github" / "workflows" / "ci.yml"
@@ -62,6 +71,14 @@ _RUN = re.compile(r"^(\s*)run:(.*)$")
 
 # The block-scalar indicators that mean "the command is on the following lines".
 _BLOCK_SCALARS = ("|", "|-", "|+", ">", ">-", ">+", "")
+
+# An `env:` key with no inline value, at any depth — job-level or step-level, both of which
+# apply to the `run:` blocks beneath them.
+_ENV = re.compile(r"^(\s*)env:\s*$")
+
+# One `KEY: value` pair inside an `env:` block. The value keeps its quotes here and is
+# stripped by the caller, so that `"src scripts"` and `src scripts` compare equal.
+_ENV_ENTRY = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*):\s*(.+?)\s*$")
 
 # `ci-gate` runs no gate: it reads `needs.*.result` so branch protection has one required
 # check instead of a list that must be edited whenever a job is added. There is nothing for
@@ -214,6 +231,58 @@ def _ci_jobs() -> dict[str, list[list[str]]]:
         jobs[job].append(_normalise("\n".join(body)))
 
     return jobs
+
+
+def _ci_env() -> dict[str, dict[str, str]]:
+    """Return every variable each job sets, keyed by job name.
+
+    Hand-parsed for the same reason as :func:`_ci_jobs` — see the module docstring. Both
+    ``env:`` depths are collected into one mapping per job, because a job-level block and a
+    step-level one are indistinguishable from the point of view of the command that runs
+    under them, which is what :data:`scripts.gates.GATE_ENV` models.
+
+    Returns:
+        Job name to its variables. A job that sets none is absent rather than empty.
+    """
+    env: dict[str, dict[str, str]] = {}
+    lines = CI.read_text(encoding="utf-8").splitlines()
+    in_jobs = False
+    job: str | None = None
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+
+        if line.rstrip() == "jobs:":
+            in_jobs = True
+            continue
+        if not in_jobs:
+            continue
+        if line.strip() and not line.startswith(" "):
+            break
+
+        match = _JOB.match(line)
+        if match:
+            job = match.group(1)
+            continue
+
+        block = _ENV.match(line)
+        if block is None or job is None:
+            continue
+
+        # Every following line indented past the `env:` key is one of its entries.
+        indent = len(block.group(1))
+        while index < len(lines):
+            entry = lines[index]
+            if entry.strip() and len(entry) - len(entry.lstrip()) <= indent:
+                break
+            index += 1
+            pair = _ENV_ENTRY.match(entry)
+            if pair is not None:
+                env.setdefault(job, {})[pair.group(1)] = pair.group(2).strip('"')
+
+    return env
 
 
 def _documented() -> dict[str, list[str]]:
@@ -453,4 +522,53 @@ class TestEachCommandMatchesCi:
             + "\n  ".join(sorted(undocumented))
             + "\n\nUpdate the '#### Running one by hand' fence to match. If the block is a "
             "diagnostic rather than a gate, declare it in _DIAGNOSTIC above."
+        )
+
+
+class TestTheGateEnvironment:
+    """`GATE_ENV` must be the environment `ci.yml` sets — in both directions (#81).
+
+    The value it carries decides which folders a gate measures, so a drift here is the
+    quiet kind: `RHIZA_DOCTEST_FOLDERS` set in CI but not in `scripts/gates.py` would mean
+    a doctest under `scripts/` runs in CI and not locally, and set in neither would mean it
+    runs nowhere while `test_doctests` *skips* and reads as a pass (#34).
+    """
+
+    def test_every_declared_variable_is_the_one_ci_sets(self) -> None:
+        """The runner must not set a value CI does not, or a different value for it."""
+        ci = _ci_env()
+        mismatched = [
+            f"{gate}: {key}={value!r} locally, {ci.get(gate, {}).get(key)!r} in ci.yml"
+            for gate, variables in GATE_ENV.items()
+            for key, value in variables.items()
+            if ci.get(gate, {}).get(key) != value
+        ]
+        assert not mismatched, (
+            "scripts/gates.py sets an environment ci.yml does not:\n  "
+            + "\n  ".join(sorted(mismatched))
+            + "\n\nGATE_ENV and the job's `env:` block are two homes for one value; update "
+            "whichever is wrong so a local run means what CI's does."
+        )
+
+    def test_ci_sets_nothing_the_runner_leaves_out(self) -> None:
+        """And the reverse, which is the direction that makes a local pass trustworthy.
+
+        `_NOT_A_GATE` is excluded because `ci-gate` sets `RESULTS` to read
+        `needs.*.result` — pipeline machinery with no gate for a contributor to reproduce,
+        the same reason its `run:` block is not in the README fence.
+        """
+        documented = _documented()
+        missing = [
+            f"{gate}: {key}={value!r}"
+            for gate, variables in _ci_env().items()
+            if gate not in _NOT_A_GATE and gate in documented
+            for key, value in variables.items()
+            if GATE_ENV.get(gate, {}).get(key) != value
+        ]
+        assert not missing, (
+            "ci.yml sets an environment scripts/gates.py does not:\n  "
+            + "\n  ".join(sorted(missing))
+            + "\n\nDeclare it in GATE_ENV, so `python scripts/gates.py <gate>` runs the "
+            "gate the way CI runs it. If it is pipeline machinery rather than part of the "
+            "gate, add its job to _NOT_A_GATE with the reason."
         )


### PR DESCRIPTION
Closes #81.

## What was wrong

`scripts/` was folded into every other quality gate one issue at a time — `ty` and
`mypy --strict` (#66), `--cov=scripts` (#69), interrogate's path list from the start — and
the doctest gate was missed. `RHIZA_DOCTEST_FOLDERS` was left unset deliberately, because
`src` is the variable's own fallback and a second home for a folder name is a second thing
to keep correct. That reasoning predated `scripts/` being in scope at all, so the fallback
resolved to a strictly smaller tree than the other three gates measured.

Nothing was failing — `scripts/*.py` carried no `>>>` examples. The defect was the absent
guard: an example added to `scripts/gates.py` would have been collected by nothing, and
`test_doctests` **skips** rather than fails when it attempts none. A check with no subject
reading as a pass is the #34 failure mode.

## The approach, and why not the alternatives

`GATE_ENV` in `scripts/gates.py` declares the value beside `SKIP_GUARD`; the `rhiza-test`
job sets it too. So `python scripts/gates.py rhiza-test` doctests what CI doctests, which
is the invariant `CLAUDE.md` states and `SKIP_GUARD` already exists to hold.

Putting it on the documented command line instead **cannot work as a config edit**:
`_run` splits a README line with `shlex.split` and runs it without a shell, so a
`RHIZA_DOCTEST_FOLDERS="src scripts" uv run …` prefix becomes `argv[0]` rather than an
assignment. It would need `_run` taught to parse leading assignments.

## Closing the two-homes gap this opens

The value is now written twice, so `tests/test_readme_gates.py` pins the two in both
directions — a variable set in CI but not the runner, or the reverse, fails the suite.
That module compared `run:` blocks only, so an `env:` block was previously invisible to
it. `ci-gate`'s `RESULTS` is excluded via the existing `_NOT_A_GATE`.

Verified by mutation: changing the CI value to `"src"` fails both new tests.

## Making the widened set non-vacuous

`select_gates` gains six real doctests — otherwise `scripts` is in scope with nothing in
it to run. **90** executed examples now: 84 under `src`, 6 in `scripts/gates.py`.

Breaking one turns the gate red, checked both ways:

```
$ uv run python scripts/gates.py rhiza-test     # with one example broken
E    scripts.gates: 2/6 failed
```

The exception example prints the message rather than expecting a traceback, because the
exception's qualified name is `gates.GatesError` or `scripts.gates.GatesError` depending
on how the module was imported.

## Gates run locally

`lint`, `typecheck`, `docs-coverage`, `test` (207 passed, 100% coverage), `rhiza-test`
(34 passed, 0 skipped) — all green.

## Note on sequencing

Branched off `main` at `c87167f`, so this does **not** contain the v0.4.0 version bump in
#82. Cut the `v0.4.0` tag before merging this, or the tag will point at a commit carrying
work its own changelog section omits.
