### PR TITLE
Close the three quality findings from #85-#87

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,70 @@
+name: CodeQL
+
+# Dataflow SAST, restored by #86.
+#
+# `rhiza_codeql.yml` used to sit here and was deleted in #52. The reason recorded in
+# ci.yml's header was the *pinned edge*: that stub called `jebel-quant/rhiza`'s reusable
+# CodeQL workflow, which meant maintaining a dependency edge to rhiza for scanning that
+# this repository does not otherwise need — and rhiza pins pytest-rhiza, so the edge ran
+# the wrong way round. Nothing in that argument was about CodeQL itself, but nothing
+# replaced it either, so the scanning went with the edge.
+#
+# This file is the scanning without the edge: `github/codeql-action` called directly, so
+# there is no `uses:` line pointing at jebel-quant/rhiza and no cycle to close.
+#
+# Why it is worth having beside `security` (bandit). bandit pattern-matches one file at a
+# time and does not follow a value across a function or module boundary; CodeQL does. The
+# closure argument ci.yml already makes for `audit` and `license` applies unchanged here:
+# pytest-rhiza is a runtime dependency of every rhiza-managed repo, so a finding in this
+# source is a finding in every consumer's test environment.
+#
+# Third-party actions are SHA-pinned with the version in a trailing comment; see ci.yml's
+# header for why a tag — even an exact one — is not enough, and .github/dependabot.yml for
+# what keeps the pin moving.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Monday 07:00 UTC, an hour before weekly.yml. The scheduled run is not redundant with
+    # the push trigger: CodeQL's query packs are updated independently of this repository,
+    # so a query added after the last commit would otherwise never run against this code.
+    - cron: "0 7 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      contents: read
+      # The one elevation, and it is what makes the job useful rather than decorative:
+      # without it the SARIF cannot be uploaded and findings never reach the Security tab.
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # `build-mode: none` because this is pure Python — there is nothing to compile, and
+      # the alternative modes exist for languages where the build is how sources are
+      # discovered. Declaring it explicitly rather than letting the action infer keeps a
+      # future language addition from silently changing what this job does.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          languages: python
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          category: "/language:python"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,75 @@
+name: Scorecard
+
+# OSSF Scorecard, restored by #86 alongside CodeQL and for the same reason: the
+# `rhiza_scorecard.yml` stub deleted in #52 called jebel-quant/rhiza's reusable workflow,
+# and the objection recorded there was to that *edge*, not to the scoring. This calls
+# `ossf/scorecard-action` directly, so no `uses:` line points at rhiza.
+#
+# What it measures that nothing else here does: this repository's own supply-chain
+# posture — whether actions are pinned, whether workflow tokens are least-privilege,
+# whether branch protection is on, whether releases are signed. Those are properties of
+# the repository rather than of the code, so neither bandit nor CodeQL nor pip-audit
+# reports on them, and several of them are conventions this repo already follows by hand
+# (SHA pins, `permissions: contents: read`) with nothing checking that they stay followed.
+#
+# Weekly rather than per-push: the inputs are repository settings and dependency metadata,
+# which do not change per commit, and the checks are rate-limited against the GitHub API.
+# The `branch_protection` check additionally reports unknown without a PAT — that is
+# expected on the default token and is not a failure of this job.
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "30 7 * * 1"  # Monday 07:30 UTC, between codeql.yml and weekly.yml
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      contents: read
+      # Upload the SARIF so findings land in the Security tab rather than only in the log.
+      security-events: write
+      # `publish_results: true` attests the run through the OIDC token. That is what lets
+      # the score be served publicly and what a consumer would check; without it the job
+      # still scores but the result stays private to this repository.
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      # Retained separately from the SARIF upload because the Security tab keeps only the
+      # findings it can map to code; the raw file carries the per-check scores and the
+      # reasons, which is what a drop in the score has to be diagnosed from.
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          sarif_file: results.sarif

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,8 +106,8 @@ from the arguments, and under `--pyargs` those point into site-packages.
 
 ### Private helpers exist because one distribution is the shared home
 
-`_fences`, `_bumpversion`, `_versions`, `_source_folder`, `_process` hold logic that
-upstream was **duplicated across bundles** — a Rust project received one file and not the
+`_fences`, `_bumpversion`, `_versions`, `_release_state`, `_source_folder`, `_process`
+hold logic that upstream was **duplicated across bundles** — a Rust project received one file and not the
 other, so a shared helper would have needed a third home both bundles shipped. One
 distribution *is* that third home, so the trade reversed. Each module's docstring records
 the specific reason; read it before folding one back into a check.
@@ -123,6 +123,15 @@ Two of them encode non-obvious decisions:
 - `_versions` asserts the declared version is *not behind* the newest tag rather than equal
   to it, because `/rhiza:release` is two-phase: phase A bumps the version on a PR, phase B
   tags the merged commit, and equality cannot hold in between (#62).
+- `_release_state` is the **upper bound** on that permission (#85). "Ahead of the newest
+  tag" describes both a release in flight and one that *stopped* — phase A merged, phase B
+  never ran — and until #85 the two were indistinguishable, so a version that was never
+  tagged and never published kept every gate green. This package sat in that state for
+  three and a half days while `rhiza-test` reported `34 passed, 0 skipped`. The check fires
+  only once the bump is on the **default branch** (an open release PR is not a stall) and
+  older than `RHIZA_RELEASE_GRACE_DAYS`, default 3. Everything git cannot answer — shallow
+  clone, no `origin/HEAD`, a version the pickaxe cannot find — is a return, not a failure:
+  reporting those as red would mirror the #34 defect it exists to catch.
 
 ## Testing model
 
@@ -156,8 +165,8 @@ mode (#34) is the one this suite is most careful about.
   is therefore opted out of in `[tool.check_test_layout]` with a recorded reason; tests are
   organised by behaviour in `tests/` instead.
 - **Docstring coverage is 100% over `src` *and* `tests`** — a test whose name is its only
-  explanation is what that bar exists to prevent. Docstrings here carry real doctests (90 of
-  them — 84 under `src`, 6 in `scripts/gates.py`); `_resolve_root` documents its ladder by
+  explanation is what that bar exists to prevent. Docstrings here carry real doctests (96 of
+  them — 90 under `src`, 6 in `scripts/gates.py`); `_resolve_root` documents its ladder by
   example precisely because a fixture needs a live session to exercise. The doctest gate
   walks both folders since #81; before that an example under `scripts/` would have been
   collected by nothing, and `test_doctests` *skips* rather than fails when it attempts
@@ -178,7 +187,10 @@ mode (#34) is the one this suite is most careful about.
 - **Nothing here invokes `jebel-quant/rhiza`.** That repo pins pytest-rhiza as a dependency,
   so calling its reusable CI would close a cycle — rhiza's workflow running the gates that
   judge the package rhiza depends on. `rhiza_release.yml` is the one exception, synced
-  verbatim because PyPI Trusted Publishing validates the exact workflow path.
+  verbatim because PyPI Trusted Publishing validates the exact workflow path. `codeql.yml`
+  and `scorecard.yml` (#86) are the shape a restored scanner takes: the first-party action
+  called directly, never rhiza's reusable wrapper, so the scanning returns without the edge
+  #52 removed.
 - **The `pytest>=8.1` floor is bisected, not guessed.** 8.0.x walks the generic ancestor
   chain of a `--pyargs` argument and dies on an unstat-able `/home` entry on GitHub runners
   (#23). The `lowest-deps` gate is what stops that floor rotting.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,28 @@ Without it the check resolves `src` alone, and a project keeping its Python else
 its examples silently unchecked — rhiza's own repo being the extreme case, with no `src/`
 at all.
 
+### How long a release may stay in flight
+
+The version checks assert the declared version is not *behind* the newest tag, and permit
+it to be *ahead* — that is what a release in flight looks like, since `/rhiza:release`
+bumps by pull request (phase A) and tags the merged commit afterwards (phase B). Nothing
+bounded how long it may lead for, so a release whose phase B never ran stayed green
+indefinitely while declaring a version that was never tagged and never published (#85).
+This package sat in exactly that state.
+
+`RHIZA_RELEASE_GRACE_DAYS` is that bound, defaulting to **3 days**. It is measured from
+the commit that wrote the version into the manifest, and only once that commit is on the
+default branch — while the release PR is open, nothing fires. A project whose cadence is
+genuinely slower raises it:
+
+```bash +RHIZA_SKIP
+RHIZA_RELEASE_GRACE_DAYS=30 uvx rhiza-task rhiza-test
+```
+
+Everything git cannot answer is a skip rather than a failure: a shallow clone, a checkout
+with no `origin/HEAD`, a manifest the version was never written into. None of those mean
+the release stalled, they mean the check has no subject.
+
 ## Two things that were decided
 
 Both of these were open questions while the split was being designed. They are settled
@@ -301,6 +323,13 @@ Publishing validates the exact workflow path. The `rhiza_codeql.yml` and
 `rhiza_scorecard.yml` stubs are gone — they called rhiza's reusable CodeQL and OSSF
 Scorecard workflows, a pinned edge to keep current for scanning this repository does not
 depend on.
+
+The *scanning* came back in #86, as `codeql.yml` and `scorecard.yml`. Only the edge was
+ever the objection: both now call `github/codeql-action` and `ossf/scorecard-action`
+directly, SHA-pinned like every other third-party action here, so there is no `uses:` line
+pointing at rhiza and no cycle. They earn their place beside `security` because bandit
+pattern-matches one file at a time and never follows a value across a boundary, and
+because nothing else here scores this repository's own supply-chain posture.
 
 The cost of dropping the Makefile was real and was stated plainly here for three releases:
 **no gate had a local entry point at all** (#49, #32). That was the call made in #52 — a

--- a/ruff.toml
+++ b/ruff.toml
@@ -175,6 +175,12 @@ line-ending = "auto"
 "src/pytest_rhiza/_versions.py" = [
     "S101",  # assert is the test idiom, and how every complaint in this package is reported
 ]
+# The bound on how long a release may stay in flight (#85). Same reasoning again: it holds
+# an assertion for the layer checks and must not sit under `checks/`, where a consumer
+# could name it on a `--pyargs` command line by mistake.
+"src/pytest_rhiza/_release_state.py" = [
+    "S101",  # assert is the test idiom, and how every complaint in this package is reported
+]
 # Project test suite only — allowances the synced .rhiza/tests should not inherit
 "tests/**/*.py" = [
     "RUF002",  # docstrings quote prose with typographic unicode (e.g. en dash)

--- a/scripts/gates.py
+++ b/scripts/gates.py
@@ -294,25 +294,14 @@ def _print_summary(selected: list[str], failed: list[str], documented: dict[str,
             print(f"  ----  {name} (not selected)")
 
 
-def main(argv: list[str] | None = None) -> int:
-    """Parse arguments, run the selected gates, and report.
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser.
 
-    Every selected gate runs even after one fails, so a single pass shows the whole
-    picture rather than stopping at the first red — the same reason ``ci-gate`` aggregates
-    instead of the jobs depending on each other.
-
-    The work is in :func:`documented_gates`, :func:`select_gates`, :func:`run_gate` and the
-    two printers; what is left here is the argument surface and the exit status. This was
-    one function until #70, where it measured CC 24 — breadth rather than nesting, but the
-    selection path it held was also the part no test reached, which is the more useful thing
-    the split bought.
-
-    Args:
-        argv: Command-line arguments, defaulting to :data:`sys.argv`.
+    Split out of :func:`main` so that function is the control flow and nothing else; the
+    option surface changes for different reasons than the exit-status logic does.
 
     Returns:
-        A process exit status: 0 when every selected gate passed, 1 when one failed, 2
-        when the selection itself was wrong.
+        The parser, with the positional gate list and the two flags.
     """
     parser = argparse.ArgumentParser(
         prog="scripts/gates.py",
@@ -321,7 +310,45 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("gates", nargs="*", help="gates to run (default: all but the destructive ones)")
     parser.add_argument("--all", action="store_true", help=f"include {', '.join(sorted(DESTRUCTIVE))}")
     parser.add_argument("--list", action="store_true", help="list the documented gates and exit")
-    args = parser.parse_args(argv)
+    return parser
+
+
+def _announce_destructive(selected: list[str]) -> None:
+    """Print the side-effect warning for each selected gate that has one.
+
+    Printed before anything runs rather than as each gate starts, so a run that will
+    perturb the working tree says so while there is still time to interrupt it.
+
+    Args:
+        selected: The gates about to run, from :func:`select_gates`.
+    """
+    for name in selected:
+        if name in DESTRUCTIVE:
+            print(f"\033[33mnote\033[0m: {name} {DESTRUCTIVE[name]}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments, run the selected gates, and report.
+
+    Every selected gate runs even after one fails, so a single pass shows the whole
+    picture rather than stopping at the first red — the same reason ``ci-gate`` aggregates
+    instead of the jobs depending on each other.
+
+    The work is in :func:`documented_gates`, :func:`select_gates`, :func:`run_gate`, the
+    two printers and :func:`_build_parser`; what is left here is the control flow and the
+    exit status. This was one function until #70, where it measured CC 24 — breadth rather
+    than nesting, but the selection path it held was also the part no test reached, which is
+    the more useful thing the split bought. #87 took the argument surface and the
+    destructive-gate notice out for the same reason, bringing it under CC 8.
+
+    Args:
+        argv: Command-line arguments, defaulting to :data:`sys.argv`.
+
+    Returns:
+        A process exit status: 0 when every selected gate passed, 1 when one failed, 2
+        when the selection itself was wrong.
+    """
+    args = _build_parser().parse_args(argv)
 
     # One handler for both failures, because they are the same answer to the user: a README
     # with no fence leaves nothing to choose from, and a typo names something that does not
@@ -336,9 +363,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: {error}", file=sys.stderr)
         return 2
 
-    for name in selected:
-        if name in DESTRUCTIVE:
-            print(f"\033[33mnote\033[0m: {name} {DESTRUCTIVE[name]}")
+    _announce_destructive(selected)
 
     failed = [name for name in selected if not run_gate(name, documented[name])]
     _print_summary(selected, failed, documented)

--- a/src/pytest_rhiza/_release_state.py
+++ b/src/pytest_rhiza/_release_state.py
@@ -1,0 +1,263 @@
+"""Whether a release that is *in flight* ever actually landed.
+
+:mod:`pytest_rhiza._versions` asserts the declared version is not **behind** the newest
+tag, and deliberately permits it to be **ahead**, because ``/rhiza:release`` is two-phase:
+phase A bumps the version on a pull request, phase B tags the merged commit, and equality
+cannot hold in between (#62). That permission is correct and this module does not touch
+it.
+
+**What it lacked was an upper bound (#85).** "Ahead of the newest tag" describes two
+states that look identical to :mod:`pytest_rhiza._versions`:
+
+* a release in flight — the PR is open, or was merged moments ago and the tag is coming;
+* a release that **stopped** — phase A merged, phase B never ran, and the version the
+  manifest declares was never tagged and never published.
+
+The second is not hypothetical. pytest-rhiza itself sat in it: ``0.4.1`` was bumped and
+merged, ``CHANGELOG.md`` carried its section, and no ``v0.4.1`` tag existed days later —
+while ``rhiza-test`` reported 34 passed, 0 skipped throughout. That is the #34 shape one
+level up: not a check that skipped, but a check whose subject was never created.
+
+**The signature this module tests for**, and why each part is needed:
+
+1. the declared version is ahead of the newest tag — a release is in flight at all;
+2. the commit that wrote that version into the manifest is reachable from the **default
+   branch** — phase A is done, so phase B is what is outstanding. While the release PR is
+   still open the bump lives only on its branch, and nothing here fires;
+3. that commit is older than :func:`grace_days` — phase B follows a merge by minutes when
+   it runs at all, so age is what separates "tagging shortly" from "never tagged".
+
+**Why a grace period rather than "merged implies tagged".** ``rhiza_release.yml`` triggers
+on ``push:`` of a tag, so tagging is a deliberate step rather than something the merge sets
+off. Failing the instant a bump merges would make the default branch red for the whole
+normal window and would fail the release's own required checks. The bound has to be loose
+enough to be uninteresting during a healthy release and tight enough that a stalled one
+cannot hide behind it.
+
+**Everything git cannot answer is a skip, not a failure.** A shallow clone, a repository
+with no ``origin/HEAD``, a manifest the pickaxe cannot find the version in — none of those
+mean the release stalled, they mean this check has no subject. Reporting them as failures
+would be the mirror of the defect it exists to catch.
+
+Security Notes:
+- S101 (assert usage): Asserts are appropriate in test code for validating conditions
+  and are the mechanism pytest reports failures through.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pytest_rhiza._process import _budget, git
+from pytest_rhiza._versions import _as_version
+
+__all__ = ["assert_release_not_stalled", "grace_days", "stalled_for"]
+
+# Days a merged-but-untagged bump may sit before it is reported. Three rather than one:
+# a release merged on a Friday should not go red over a weekend. Three rather than ten:
+# this package released 0.2.2, 0.3.0, 0.4.0 and 0.4.1 inside a single day, and a bound
+# looser than the cadence it guards cannot catch anything.
+DEFAULT_GRACE_DAYS = 3
+GRACE_DAYS_ENV = "RHIZA_RELEASE_GRACE_DAYS"
+
+
+def grace_days() -> int:
+    """Return how many days a merged bump may go untagged before this is a failure.
+
+    Overridable for a project whose release cadence is genuinely slower than the default
+    assumes — the same knob, and the same reasoning, as the timeouts in
+    :mod:`pytest_rhiza._process`, whose :func:`~pytest_rhiza._process._budget` this reuses
+    rather than re-implementing "a positive integer from the environment, or a default"
+    a second time.
+
+    Returns:
+        Seconds' worth of days, from :data:`GRACE_DAYS_ENV` or :data:`DEFAULT_GRACE_DAYS`.
+    """
+    return _budget(GRACE_DAYS_ENV, DEFAULT_GRACE_DAYS)
+
+
+def default_branch(root: Path) -> str | None:
+    """Return the default branch as a remote-tracking ref, or None if git cannot say.
+
+    ``origin/HEAD`` is what names the default branch locally, and it is absent often
+    enough to matter: a bare ``git clone`` sets it, ``actions/checkout`` does not always,
+    and a repository with no remote never has one. Absent means unjudgeable.
+
+    Args:
+        root: Repository to ask.
+
+    Returns:
+        Something like ``origin/main``, or None when there is no ``origin/HEAD``.
+    """
+    result = git(root, "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def merged_bump_date(root: Path, branch: str, manifest: str, declared: str) -> str | None:
+    """Return when ``declared`` was written into ``manifest`` on ``branch``.
+
+    Found with git's pickaxe (``-S``), which reports the commits where the number of
+    occurrences of a string in a path changed — so the bump commit is the newest one on
+    the default branch that changed how often the declared version appears in the
+    manifest. Scoping to the one path is what keeps it from matching a version-shaped
+    string elsewhere in the tree.
+
+    Args:
+        root: Repository to ask.
+        branch: The ref to search, from :func:`default_branch`. Searching the default
+            branch rather than ``HEAD`` is what distinguishes a merged bump from one
+            still on an open release PR.
+        manifest: Repository-relative path of the file declaring the version.
+        declared: The version string to look for.
+
+    Returns:
+        The committer date in ISO 8601, or None when no such commit is on that branch —
+        which is the ordinary answer while a release PR is still open.
+    """
+    result = git(root, "log", "-1", "--format=%cI", f"-S{declared}", branch, "--", manifest)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def stalled_for(committed: str, now: datetime) -> int | None:
+    """Return whole days between an ISO 8601 commit date and ``now``.
+
+    Args:
+        committed: A committer date as git's ``%cI`` writes it.
+        now: The moment to measure against, timezone-aware.
+
+    Returns:
+        Whole days elapsed, or None when ``committed`` cannot be read as an aware
+        timestamp — unparseable input is unjudgeable, in keeping with the rest of this
+        module.
+
+    Examples:
+        >>> from datetime import datetime, timezone
+        >>> now = datetime(2026, 8, 25, 12, 0, tzinfo=timezone.utc)
+        >>> stalled_for("2026-08-21T20:16:41+04:00", now)
+        3
+
+        The same instant is zero days, not one:
+
+        >>> stalled_for("2026-08-25T12:00:00+00:00", now)
+        0
+
+        A date git could not have written is unjudgeable rather than an error:
+
+        >>> stalled_for("last Tuesday", now) is None
+        True
+
+        So is one with no offset — comparing it to an aware ``now`` would raise, and a
+        naive timestamp genuinely does not identify a moment:
+
+        >>> stalled_for("2026-08-21T20:16:41", now) is None
+        True
+    """
+    try:
+        moment = datetime.fromisoformat(committed)
+    except ValueError:
+        return None
+    if moment.tzinfo is None:
+        return None
+    return (now - moment).days
+
+
+def _stalled_release(
+    root: Path,
+    latest_tag: str,
+    declared: str,
+    *,
+    manifest: str,
+    now: datetime,
+) -> tuple[str, int] | None:
+    """Return the default branch and how long the bump has sat on it, or None to say nothing.
+
+    Every rung that cannot be established returns None rather than raising, so
+    :func:`assert_release_not_stalled` is left holding one decision — fail or not — and
+    this function holds the four ways there is nothing to decide. Split out at CC 9,
+    under the bar #87 set for this repository.
+
+    Args:
+        root: The repository under test.
+        latest_tag: The newest ``vX.Y.Z`` tag.
+        declared: The version the manifest declares.
+        manifest: Repository-relative path of that manifest.
+        now: The moment to measure against, timezone-aware.
+
+    Returns:
+        The default branch and whole days since the bump merged into it, or None when
+        either version is malformed, no release is in flight, git cannot name the default
+        branch, the bump is not on it, or its date cannot be read.
+    """
+    tag_version = _as_version(latest_tag.lstrip("v"))
+    declared_version = _as_version(declared)
+    if tag_version is None or declared_version is None:
+        return None  # malformed; assert_declared_version_not_behind_tag reports it
+    if declared_version <= tag_version:
+        return None  # no release in flight — nothing to have stalled
+
+    branch = default_branch(root)
+    if branch is None:
+        return None  # no origin/HEAD, so "merged" has no meaning here
+
+    committed = merged_bump_date(root, branch, manifest, declared)
+    if committed is None:
+        return None  # the bump is not on the default branch: phase A is still in flight
+
+    elapsed = stalled_for(committed, now)
+    if elapsed is None:  # pragma: no cover - defensive; git's %cI is always aware ISO 8601
+        return None
+    return branch, elapsed
+
+
+def assert_release_not_stalled(
+    root: Path,
+    latest_tag: str,
+    declared: str,
+    *,
+    manifest: str,
+    now: datetime | None = None,
+) -> None:
+    """Assert a version ahead of the newest tag is a release in flight, not an abandoned one.
+
+    The four states in which there is nothing to judge are :func:`_stalled_release`'s
+    business and all of them return quietly; see the module docstring for why none of them
+    is a failure. What is left here is the one comparison that can fail.
+
+    Args:
+        root: The repository under test.
+        latest_tag: The newest ``vX.Y.Z`` tag, from the ``latest_tag`` fixture.
+        declared: The version the layer's manifest declares.
+        manifest: Repository-relative path of that manifest, for the pickaxe and the
+            failure message.
+        now: The moment to measure against; defaults to the current UTC time. Injected so
+            the elapsed-time branch is testable without waiting days for it.
+
+    Raises:
+        AssertionError: If the bump merged into the default branch more than
+            :func:`grace_days` days ago and no tag names the version it declared.
+    """
+    state = _stalled_release(
+        root,
+        latest_tag,
+        declared,
+        manifest=manifest,
+        now=now or datetime.now(UTC),
+    )
+    if state is None:
+        return
+    branch, elapsed = state
+
+    allowed = grace_days()
+    assert elapsed <= allowed, (
+        f"Version {declared!r} in {manifest} has been merged into {branch} for {elapsed} days "
+        f"with no matching tag — the newest is {latest_tag!r}. /rhiza:release is two-phase and a "
+        f"version ahead of the newest tag is normally a release in flight, but phase B tags the "
+        f"merged commit within minutes, so {elapsed} days means phase B never ran: v{declared} was "
+        f"never tagged and never published. Tag the merged commit to finish the release, or set "
+        f"{GRACE_DAYS_ENV} above {allowed} if this project's cadence is genuinely slower."
+    )

--- a/src/pytest_rhiza/checks/test_cargo_toml.py
+++ b/src/pytest_rhiza/checks/test_cargo_toml.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import pytest
 
 from pytest_rhiza._bumpversion import SyncedBumpversionConfig
+from pytest_rhiza._release_state import assert_release_not_stalled
 from pytest_rhiza._toml import TomlTable
 from pytest_rhiza._versions import assert_declared_version_not_behind_tag
 
@@ -191,3 +192,19 @@ class TestGitTagVersion:
                 "it in Cargo.toml, so the next release would fail to find it."
             ),
         )
+
+    def test_the_bump_that_produced_this_version_was_tagged(
+        self, latest_tag: str, package: TomlTable, root: Path
+    ) -> None:
+        """The bump that produced this version must have been tagged (#85).
+
+        ``assert_declared_version_not_behind_tag`` permits the manifest to lead the newest
+        tag, because that is what a release in flight looks like. Nothing bounded how long
+        it may lead for, so a release whose phase B never ran stayed green indefinitely
+        while declaring a version that was never tagged and never published. See
+        :mod:`pytest_rhiza._release_state`.
+        """
+        version = package.get("version")
+        if isinstance(version, dict):
+            pytest.skip("[package].version is inherited from the workspace")
+        assert_release_not_stalled(root, latest_tag, str(version), manifest="Cargo.toml")

--- a/src/pytest_rhiza/checks/test_docstrings.py
+++ b/src/pytest_rhiza/checks/test_docstrings.py
@@ -71,6 +71,51 @@ def _find_packages(src_path: Path) -> Iterator[Path]:
             yield package_dir
 
 
+def _import_locations(module: ModuleType) -> list[Path]:
+    """Return the resolved directories ``module`` was imported from.
+
+    A package carries ``__path__``; a plain module does not, and ``getattr`` returning
+    ``[]`` for it is deliberate. A same-named *module* shadowing a package cannot be the
+    folder under test, so an empty list correctly falls through to eviction.
+
+    Args:
+        module: An entry from ``sys.modules``.
+
+    Returns:
+        Its ``__path__`` entries, resolved, or an empty list when it has none.
+    """
+    return [Path(entry).resolve() for entry in getattr(module, "__path__", [])]
+
+
+def _describe(located: list[Path]) -> list[str] | str:
+    """Render import locations for the eviction log line.
+
+    Args:
+        located: The paths from :func:`_import_locations`.
+
+    Returns:
+        The paths as strings, or a stand-in phrase when there are none — a namespace
+        package or a C extension can be in ``sys.modules`` with nothing to point at, and
+        an empty list in the log reads as a bug rather than as an answer.
+    """
+    return [str(path) for path in located] or "an unknown location"
+
+
+def _cached_names(top_level: str) -> list[str]:
+    """Return every ``sys.modules`` key belonging to one top-level package.
+
+    Materialised into a list before the caller deletes anything, because deleting from
+    ``sys.modules`` while iterating it raises.
+
+    Args:
+        top_level: The package name, without dots.
+
+    Returns:
+        The package itself and each of its imported submodules.
+    """
+    return [name for name in list(sys.modules) if name == top_level or name.startswith(f"{top_level}.")]
+
+
 def _evict_shadowing_package(
     monkeypatch: pytest.MonkeyPatch, logger: logging.Logger, import_root: Path, package_dir: Path
 ) -> None:
@@ -100,16 +145,16 @@ def _evict_shadowing_package(
     existing = sys.modules.get(top_level)
     if existing is None:
         return
-    located = [Path(entry).resolve() for entry in getattr(existing, "__path__", [])]
+    located = _import_locations(existing)
     if (import_root / top_level).resolve() in located:
         return  # already the folder under test; nothing is being shadowed
     logger.info(
         "Evicting cached package %s (imported from %s) so %s is what gets measured",
         top_level,
-        [str(path) for path in located] or "an unknown location",
+        _describe(located),
         import_root / top_level,
     )
-    for cached in [name for name in list(sys.modules) if name == top_level or name.startswith(f"{top_level}.")]:
+    for cached in _cached_names(top_level):
         monkeypatch.delitem(sys.modules, cached, raising=False)
 
 

--- a/src/pytest_rhiza/checks/test_go_module.py
+++ b/src/pytest_rhiza/checks/test_go_module.py
@@ -31,6 +31,7 @@ from pathlib import Path
 import pytest
 
 from pytest_rhiza._bumpversion import SyncedBumpversionConfig
+from pytest_rhiza._release_state import assert_release_not_stalled
 from pytest_rhiza._versions import assert_declared_version_not_behind_tag
 
 # The one place a Go module's version exists in the source tree.
@@ -180,4 +181,22 @@ class TestGitTagVersion:
                 "consumers resolve the module at the tag, so the built binary would report a "
                 "version older than the one that can be fetched."
             ),
+        )
+
+    def test_the_bump_that_produced_this_version_was_tagged(
+        self, latest_tag: str, declared_version: str, root: Path
+    ) -> None:
+        """The bump that produced this version must have been tagged (#85).
+
+        ``assert_declared_version_not_behind_tag`` permits the manifest to lead the newest
+        tag, because that is what a release in flight looks like. Nothing bounded how long
+        it may lead for, so a release whose phase B never ran stayed green indefinitely
+        while declaring a version that was never tagged and never published. See
+        :mod:`pytest_rhiza._release_state`.
+        """
+        assert_release_not_stalled(
+            root,
+            latest_tag,
+            declared_version,
+            manifest=_VERSION_GO.as_posix(),
         )

--- a/src/pytest_rhiza/checks/test_pyproject.py
+++ b/src/pytest_rhiza/checks/test_pyproject.py
@@ -35,6 +35,7 @@ from pytest_rhiza._bumpversion import (
     legacy_config_hint,
     shadowing_configs,
 )
+from pytest_rhiza._release_state import assert_release_not_stalled
 from pytest_rhiza._toml import TomlTable
 from pytest_rhiza._versions import assert_declared_version_not_behind_tag
 
@@ -318,4 +319,22 @@ class TestGitTagVersion:
                 "bump-my-version reads [project].version natively, so the next release would "
                 "bump from a number older than what is already published."
             ),
+        )
+
+    def test_the_bump_that_produced_this_version_was_tagged(
+        self, latest_tag: str, project: TomlTable, root: Path
+    ) -> None:
+        """The bump that produced this version must have been tagged (#85).
+
+        ``assert_declared_version_not_behind_tag`` permits the manifest to lead the newest
+        tag, because that is what a release in flight looks like. Nothing bounded how long
+        it may lead for, so a release whose phase B never ran stayed green indefinitely
+        while declaring a version that was never tagged and never published. See
+        :mod:`pytest_rhiza._release_state`.
+        """
+        assert_release_not_stalled(
+            root,
+            latest_tag,
+            str(project.get("version", "")),
+            manifest="pyproject.toml",
         )

--- a/tests/test_check_cargo_toml.py
+++ b/tests/test_check_cargo_toml.py
@@ -44,7 +44,7 @@ search = '\\[package\\]([\\s\\S]*?)version = "{current_version}"'
 replace = '[package]\\1version = "{new_version}"'
 """
 
-TOTAL_CHECKS = 17
+TOTAL_CHECKS = 18
 
 
 def _crate(**extra: str) -> dict[str, str]:

--- a/tests/test_check_go_module.py
+++ b/tests/test_check_go_module.py
@@ -45,7 +45,7 @@ replace = 'const Version = "{new_version}"'
 
 VERSION_GO = "internal/version/version.go"
 
-TOTAL_CHECKS = 12
+TOTAL_CHECKS = 13
 
 
 def _module(**extra: str) -> dict[str, str]:

--- a/tests/test_check_pyproject.py
+++ b/tests/test_check_pyproject.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+import pytest
+
 if TYPE_CHECKING:  # pragma: no cover - import only for the fixture's type
     from conftest import Subject
 
@@ -49,7 +51,7 @@ tag = false
 
 # Every test in the module, for the sound case. Asserted as a number so that a check
 # lost to a collection change shows up here rather than passing quietly.
-TOTAL_CHECKS = 27
+TOTAL_CHECKS = 28
 
 
 class TestSoundSubject:
@@ -343,3 +345,37 @@ class TestTagAgreement:
 
         assert result.returncode == 0, result.stdout + result.stderr
         assert "No version tags found" in result.stdout, result.stdout
+
+
+class TestStalledRelease:
+    """A release whose phase B never ran must go red rather than stay quietly green (#85)."""
+
+    def test_a_bump_merged_long_ago_with_no_matching_tag_is_reported(
+        self, subject: Callable[..., Subject], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The state pytest-rhiza itself sat in: 0.4.1 declared, merged, and never tagged.
+
+        The commit is backdated through ``GIT_COMMITTER_DATE`` rather than the check being
+        handed a fake clock, because what is under test here is the whole path a consumer
+        runs — the fixture, the pickaxe and the assertion — not just the arithmetic.
+        """
+        monkeypatch.setenv("GIT_COMMITTER_DATE", "2020-01-01T00:00:00+0000")
+        repo = subject({"pyproject.toml": SOUND_PYPROJECT, "README.md": "# Demo\n"}, tag="v1.2.2")
+        repo.git("update-ref", "refs/remotes/origin/main", "HEAD")
+        repo.git("symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+
+        result = repo.run("test_pyproject", args=("-k", "bump_that_produced"))
+
+        assert result.returncode != 0
+        assert "never tagged and never published" in result.stdout, result.stdout
+
+    def test_a_release_in_flight_still_passes(self, subject: Callable[..., Subject]) -> None:
+        """The window #62 opened deliberately stays open: a fresh merge is not a stall."""
+        repo = subject({"pyproject.toml": SOUND_PYPROJECT, "README.md": "# Demo\n"}, tag="v1.2.2")
+        repo.git("update-ref", "refs/remotes/origin/main", "HEAD")
+        repo.git("symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+
+        result = repo.run("test_pyproject", args=("-k", "bump_that_produced"))
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "1 passed" in result.stdout, result.stdout

--- a/tests/test_release_state.py
+++ b/tests/test_release_state.py
@@ -1,0 +1,185 @@
+"""Unit tests for ``_release_state``: the bound on how long a release may stay in flight.
+
+``_versions`` permits the declared version to lead the newest tag, because that is what a
+release in flight looks like (#62). ``_release_state`` bounds how long it may lead for
+(#85). Both halves matter here: a release that is genuinely in flight must stay green, and
+one that stopped must go red, so most of these tests are about the *quiet* paths.
+
+The git-backed functions are exercised against real throwaway repositories from the
+``subject`` factory rather than against a mocked ``git``, for the same reason the checks
+are: what is being asserted is what git actually answers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pytest_rhiza._release_state import (
+    DEFAULT_GRACE_DAYS,
+    GRACE_DAYS_ENV,
+    assert_release_not_stalled,
+    default_branch,
+    grace_days,
+    merged_bump_date,
+    stalled_for,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - import only for the fixture's type
+    from conftest import Subject
+
+PYPROJECT = """
+[project]
+name = "demo"
+version = "0.4.1"
+"""
+
+
+def _with_origin(repo: Subject) -> Subject:
+    """Give a subject an ``origin/HEAD`` without giving it a remote.
+
+    ``default_branch`` reads ``refs/remotes/origin/HEAD``, which a bare ``git init`` never
+    writes. Creating the two refs by hand is enough and avoids a second repository: what
+    is under test is the lookup, not git's clone machinery.
+
+    Args:
+        repo: The subject to annotate.
+
+    Returns:
+        The same subject, now with ``origin/HEAD`` pointing at ``origin/main``.
+    """
+    repo.git("update-ref", "refs/remotes/origin/main", "HEAD")
+    repo.git("symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+    return repo
+
+
+class TestGraceDays:
+    """The bound is a default with an environment override, like the process timeouts."""
+
+    def test_the_default_applies_when_nothing_is_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unset variable means the default rather than no bound at all."""
+        monkeypatch.delenv(GRACE_DAYS_ENV, raising=False)
+        assert grace_days() == DEFAULT_GRACE_DAYS
+
+    def test_a_slower_cadence_can_raise_it(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A project that genuinely releases less often is the case the knob exists for."""
+        monkeypatch.setenv(GRACE_DAYS_ENV, "30")
+        assert grace_days() == 30
+
+    def test_a_typo_falls_back_rather_than_removing_the_bound(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A misspelled value must not be able to disable the check silently."""
+        monkeypatch.setenv(GRACE_DAYS_ENV, "soon")
+        assert grace_days() == DEFAULT_GRACE_DAYS
+
+
+class TestDefaultBranch:
+    """Naming the default branch, and admitting when git cannot."""
+
+    def test_it_reads_origin_head(self, subject: Callable[..., Subject]) -> None:
+        """The ordinary case: a clone has origin/HEAD and it names the default branch."""
+        repo = _with_origin(subject({"pyproject.toml": PYPROJECT}, tag="v0.4.0"))
+
+        assert default_branch(repo.path) == "origin/main"
+
+    def test_a_repository_without_a_remote_answers_none(self, subject: Callable[..., Subject]) -> None:
+        """`git init` writes no origin/HEAD, and that is unjudgeable rather than wrong."""
+        repo = subject({"pyproject.toml": PYPROJECT}, tag="v0.4.0")
+
+        assert default_branch(repo.path) is None
+
+
+class TestMergedBumpDate:
+    """Finding the commit that wrote the declared version into the manifest."""
+
+    def test_it_finds_the_commit_that_introduced_the_version(self, subject: Callable[..., Subject]) -> None:
+        """The pickaxe reports the commit where the version's occurrence count changed."""
+        repo = _with_origin(subject({"pyproject.toml": PYPROJECT}, tag="v0.4.0"))
+
+        found = merged_bump_date(repo.path, "origin/main", "pyproject.toml", "0.4.1")
+
+        assert found is not None
+        assert stalled_for(found, datetime.now(UTC)) == 0
+
+    def test_a_version_never_written_to_the_manifest_answers_none(self, subject: Callable[..., Subject]) -> None:
+        """Nothing on the default branch introduced it, which is phase A still in flight."""
+        repo = _with_origin(subject({"pyproject.toml": PYPROJECT}, tag="v0.4.0"))
+
+        assert merged_bump_date(repo.path, "origin/main", "pyproject.toml", "9.9.9") is None
+
+    def test_a_ref_git_cannot_resolve_answers_none(self, subject: Callable[..., Subject]) -> None:
+        """A branch that does not exist is unjudgeable, not a stalled release."""
+        repo = subject({"pyproject.toml": PYPROJECT}, tag="v0.4.0")
+
+        assert merged_bump_date(repo.path, "origin/nope", "pyproject.toml", "0.4.1") is None
+
+
+class TestStalledFor:
+    """Reading git's committer date, and refusing the values it cannot have written."""
+
+    def test_whole_days_elapsed(self) -> None:
+        """The number in the failure message is whole days, not a fraction."""
+        now = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
+
+        assert stalled_for("2026-08-21T20:16:41+04:00", now) == 3
+
+    def test_an_unparseable_date_is_unjudgeable(self) -> None:
+        """Something git could not have written means no verdict, rather than a failure."""
+        assert stalled_for("last Tuesday", datetime.now(UTC)) is None
+
+    def test_a_naive_timestamp_is_unjudgeable(self) -> None:
+        """Comparing naive to aware raises; a naive stamp also names no actual moment."""
+        assert stalled_for("2026-08-21T20:16:41", datetime.now(UTC)) is None
+
+
+class TestAssertReleaseNotStalled:
+    """The assertion itself: quiet in every state but the one it exists to catch."""
+
+    def test_a_bump_merged_long_ago_and_never_tagged_fails(self, subject: Callable[..., Subject]) -> None:
+        """The #85 state: phase A merged, phase B never ran, and nothing said so."""
+        repo = _with_origin(subject({"pyproject.toml": PYPROJECT}, tag="v0.4.0"))
+        later = datetime.now(UTC) + timedelta(days=10)
+
+        with pytest.raises(AssertionError, match="never tagged and never published"):
+            assert_release_not_stalled(repo.path, "v0.4.0", "0.4.1", manifest="pyproject.toml", now=later)
+
+    def test_a_release_merged_moments_ago_is_still_in_flight(self, subject: Callable[..., Subject]) -> None:
+        """Phase B follows a merge by minutes, and that window must stay green."""
+        repo = _with_origin(subject({"pyproject.toml": PYPROJECT}, tag="v0.4.0"))
+
+        assert_release_not_stalled(repo.path, "v0.4.0", "0.4.1", manifest="pyproject.toml")
+
+    def test_the_steady_state_is_quiet(self, subject: Callable[..., Subject]) -> None:
+        """Declared equals the newest tag: no release in flight, nothing to bound."""
+        repo = _with_origin(subject({"pyproject.toml": PYPROJECT}, tag="v0.4.1"))
+        later = datetime.now(UTC) + timedelta(days=365)
+
+        assert_release_not_stalled(repo.path, "v0.4.1", "0.4.1", manifest="pyproject.toml", now=later)
+
+    def test_an_open_release_pr_is_quiet(self, subject: Callable[..., Subject]) -> None:
+        """While the bump is only on the PR branch it is not on the default branch."""
+        repo = subject({"pyproject.toml": PYPROJECT}, tag="v0.4.0")
+        repo.git("update-ref", "refs/remotes/origin/main", "HEAD")
+        repo.git("symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main")
+        repo.write({"pyproject.toml": PYPROJECT.replace("0.4.1", "0.5.0")})
+        repo.commit("chore: release v0.5.0")
+        later = datetime.now(UTC) + timedelta(days=10)
+
+        # origin/main still points at the seed commit, so 0.5.0 is not merged.
+        assert_release_not_stalled(repo.path, "v0.4.0", "0.5.0", manifest="pyproject.toml", now=later)
+
+    def test_a_repository_without_origin_head_is_quiet(self, subject: Callable[..., Subject]) -> None:
+        """With no default branch, "merged" has no meaning and there is nothing to judge."""
+        repo = subject({"pyproject.toml": PYPROJECT}, tag="v0.4.0")
+        later = datetime.now(UTC) + timedelta(days=10)
+
+        assert_release_not_stalled(repo.path, "v0.4.0", "0.4.1", manifest="pyproject.toml", now=later)
+
+    def test_a_malformed_version_is_left_to_the_other_assertion(self, subject: Callable[..., Subject]) -> None:
+        """`assert_declared_version_not_behind_tag` reports these; two reports is noise."""
+        repo = _with_origin(subject({"pyproject.toml": PYPROJECT}, tag="v0.4.0"))
+
+        assert_release_not_stalled(repo.path, "v0.4.0", "not-a-version", manifest="pyproject.toml")
+        assert_release_not_stalled(repo.path, "vNOPE", "0.4.1", manifest="pyproject.toml")


### PR DESCRIPTION
Closes the three findings from the `/rhiza:quality` run: #87, #86, and the code half of #85.

Three commits, one per issue, each independently reviewable.

## `refactor:` bring every block under CC 8 — closes #87

| Block | Before | After |
|---|---|---|
| `_evict_shadowing_package` | B (10) | **A** |
| `gates.py:main` | B (9) | **A (6)** |

Extracted `_import_locations`, `_describe`, `_cached_names` from the first; `_build_parser` and `_announce_destructive` from the second. No block anywhere now exceeds CC 8; average over `src` + `scripts` improves **3.078 → 2.986**; every module stays MI rank A.

Follows the precedent #70 set at CC 24: the payoff is the separately-reachable path, not the number. `main`'s docstring claimed it still held "the argument surface", which the split makes false — corrected rather than left to rot.

## `ci:` restore CodeQL and OSSF Scorecard — closes #86

#52 deleted `rhiza_codeql.yml` and `rhiza_scorecard.yml`. The recorded objection was the **pinned edge** to `jebel-quant/rhiza`, not the scanning — but nothing replaced it, so the scanning went with the edge.

`codeql.yml` and `scorecard.yml` call `github/codeql-action` and `ossf/scorecard-action` **directly**: no `uses:` line points at rhiza, so the cycle stays closed. SHA-pinned with version comments like every other third-party action here; dependabot's existing `github-actions` entry at `/` tracks them with no config change.

They earn their place beside `security`: bandit pattern-matches one file at a time and never follows a value across a boundary, and nothing here scored this repository's own supply-chain posture at all.

## `feat:` bound how long a release may stay in flight — refs #85

`assert_declared_version_not_behind_tag` permits the declared version to lead the newest tag, because that is what a release in flight looks like (#62). **That permission is correct and is untouched.** What it lacked was an upper bound.

"Ahead of the newest tag" described two indistinguishable states: a release in flight, and one that *stopped*. This package sat in the second for three and a half days while `rhiza-test` reported `34 passed, 0 skipped` — the #34 shape one level up: not a check that skipped, but a check whose subject was never created.

`_release_state` fires only when all three hold:

1. the declared version leads the newest tag;
2. the bump commit is on the **default branch** — an open release PR never fires;
3. it is older than `RHIZA_RELEASE_GRACE_DAYS` (default 3).

A grace period rather than "merged implies tagged", because `rhiza_release.yml` triggers on tag push: failing the instant a bump merges would make `main` red for the whole normal window and fail the release's own required checks.

Everything git cannot answer — shallow clone, no `origin/HEAD`, a version the pickaxe cannot find — returns quietly. Reporting those as red would mirror the defect this exists to catch.

Wired into all three language layers so the invariant cannot disagree between them.

### Verified against this repository

```
Version '0.4.1' in pyproject.toml has been merged into origin/main for 4 days
with no matching tag — the newest is 'v0.4.0'. … phase B never ran: v0.4.1 was
never tagged and never published.
```

**#85 stays open**, because its other half is a release action rather than a code change: `v0.4.1` is still untagged and unpublished. Note that at merge time the bump is right at the 3-day boundary, so `rhiza-test` will go red on `main` until the tag is pushed. That is the check working, not a regression.

## Gates

All ten pass locally: lint, typecheck, docs-coverage, deptry, security, audit, license, test, rhiza-test, lowest-deps.

- **226 tests** (+19), coverage back to **100.00%** against the 90 floor
- docstring coverage **100%**; doctests 84 → **90** under `src`
- no block above CC 8; every module MI rank A
- `uv.lock` unchanged (`lowest-deps` restored it)

`README.md` and `CLAUDE.md` updated for the new module, the new environment variable and the restored workflows. `ruff.toml` grants `_release_state.py` the S101 allowance already granted to `_versions.py` and `_bumpversion.py`, for the same recorded reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
