### PR TITLE
Lint the files git does not know about yet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,15 @@ python scripts/gates.py --list       # what is defined, without running anything
 makes running the runner equivalent to running CI. Adding a gate means editing `ci.yml` and
 the README fence; the runner picks it up with no change.
 
+It does exactly three things more than the fence says, each declared in a table so it lands
+in a reviewable diff: `SKIP_GUARD` (#34), `GATE_ENV` (#81), and `GIT_SCOPED` (#89). The
+third is the subtlest: `prek run --all-files` is scoped by **git**, not by the filesystem, so
+`lint` alone could go green on an untracked module that CI rejects — which is how #89 was
+found, when `_release_state.py` passed the gate while untracked and failed `ruff check` the
+moment it was staged. The second pass swaps `--all-files` for `--files <paths>` **in the
+gate's own documented command**, so the no-recipes property survives; writing a fresh `prek`
+line here would have been the second home #52 removed.
+
 Two gates have side effects worth knowing before running them:
 
 - `lowest-deps` (`uv sync --resolution lowest-direct`) **rewrites `uv.lock`'s resolution in

--- a/README.md
+++ b/README.md
@@ -299,6 +299,15 @@ for you, in a `finally`, so a failing or interrupted run recovers too and even `
 `git status` clean (#71). And `rhiza-test` carries the `grep` guard, so a local pass means
 what CI's does instead of going green on `32 passed, 2 skipped`.
 
+`lint` gets a second pass over anything git neither tracks nor ignores (#89). Its
+documented command line is `prek run --all-files`, which means every file *git knows about* —
+so an untracked module is invisible to it, while `typecheck`, `docs-coverage` and `test` all
+walk the tree and see it. A fresh CI checkout has everything tracked, so the gap only ever
+showed up as a red CI job on a green local run. The extra pass is the same documented
+command with `--all-files` swapped for `--files <paths>`, not a second `prek` invocation
+written here; a file that is genuinely disposable belongs in `.gitignore`, which is what the
+note printed alongside it says.
+
 Every selected gate runs even after one fails, and the summary at the end is the whole
 picture — the same reason `ci-gate` aggregates rather than the jobs depending on each other.
 

--- a/scripts/gates.py
+++ b/scripts/gates.py
@@ -88,6 +88,25 @@ GATE_ENV: dict[str, dict[str, str]] = {
     "rhiza-test": {"RHIZA_DOCTEST_FOLDERS": "src scripts"},
 }
 
+#: Gates whose documented command line is scoped by **git** rather than by the filesystem,
+#: mapped to the flag that does the scoping (#89). ``prek run --all-files`` means every file
+#: *git knows about*, so an untracked one is invisible to it — while `typecheck`,
+#: `docs-coverage` and `test` all walk the tree and see it. CI never reproduces the gap,
+#: because a fresh checkout has everything tracked, so the gate that exists to make a local
+#: pass mean what CI's does could go green on a module CI would reject.
+#:
+#: That is not a corner case: a brand-new module is exactly where a missing
+#: ``[lint.per-file-ignores]`` entry is most likely, because the entry cannot exist yet. It
+#: is how #89 was found — ``_release_state.py`` passed this gate while untracked and failed
+#: ``ruff check`` the moment it was staged.
+#:
+#: The second pass is built by swapping this flag for ``--files <paths>`` in the gate's
+#: *own* documented command, rather than by writing a second prek invocation here. That
+#: keeps the property #66 was careful about: the runner holds no recipes, only the README's.
+GIT_SCOPED: dict[str, str] = {
+    "lint": "--all-files",
+}
+
 _SKIPPED_MESSAGE = (
     "A self-applied check skipped. A skipped assertion reads as a pass, which is the "
     "defect this guard exists to prevent (#34)."
@@ -154,9 +173,10 @@ def _run(command: str, *, capture: bool, env: dict[str, str] | None = None) -> t
 
     # S603/B603 are suppressed on both calls below for one reason: the argument list comes
     # from README.md in this repository — reviewed content, and already the trust boundary
-    # `checks/test_readme_validation` executes under — and there is no shell, so nothing in
-    # it is re-interpreted. The reason lives here rather than trailing the directive,
-    # because prose after the code is what ruff reads as a second code.
+    # `checks/test_readme_validation` executes under — or from a constant in this module
+    # (:data:`RESTORE_COMMAND`, :func:`untracked_files`'s query). There is no shell, so
+    # nothing in it is re-interpreted. The reason lives here rather than trailing the
+    # directive, because prose after the code is what ruff reads as a second code.
     if not capture:
         finished = subprocess.run(argv, cwd=ROOT, check=False, env=child_env)  # noqa: S603  # nosec B603
         return finished.returncode, ""
@@ -167,6 +187,66 @@ def _run(command: str, *, capture: bool, env: dict[str, str] | None = None) -> t
     sys.stdout.write(proc.stdout)
     sys.stderr.write(proc.stderr)
     return proc.returncode, proc.stdout
+
+
+def untracked_files() -> list[str]:
+    """Return the files git neither tracks nor ignores.
+
+    ``--exclude-standard`` is what keeps this honest: a path in ``.gitignore`` is a path the
+    repository has deliberately disowned, and linting it would turn the fix for a noisy
+    scratch file into a lint failure. What is left is the set a contributor is on the way to
+    committing.
+
+    Returns:
+        Repository-relative paths, or an empty list when git cannot answer — outside a
+        repository, or with no git on PATH. Unknown is treated as "nothing extra to lint"
+        rather than as an error, because this pass is a supplement to the documented
+        command and must not be able to fail a gate on its own.
+    """
+    status, stdout = _run("git ls-files --others --exclude-standard", capture=True)
+    if status != 0:
+        return []
+    return [line.strip() for line in stdout.splitlines() if line.strip()]
+
+
+def _files_flag(paths: list[str]) -> str:
+    """Render paths as the ``--files`` argument that replaces a whole-tree flag.
+
+    Args:
+        paths: Repository-relative paths, from :func:`untracked_files`.
+
+    Returns:
+        ``--files`` followed by each path, quoted — the command is re-split with
+        :func:`shlex.split`, so a path containing a space has to survive that round trip.
+    """
+    return "--files " + " ".join(shlex.quote(path) for path in paths)
+
+
+def _untracked_pass(name: str, commands: list[str]) -> list[str]:
+    """Return the extra command lines covering what a git-scoped gate would skip.
+
+    Empty for every gate not in :data:`GIT_SCOPED`, and empty for those too whenever there
+    is nothing untracked — which is the normal state of a clean checkout, so this costs a
+    single ``git ls-files`` and no extra child process.
+
+    Args:
+        name: The gate name.
+        commands: Its documented command lines, from :func:`documented_gates`.
+
+    Returns:
+        The scoped commands with the whole-tree flag swapped for ``--files <paths>``, in
+        the order they are documented.
+    """
+    flag = GIT_SCOPED.get(name)
+    if flag is None:
+        return []
+    scoped = [command for command in commands if flag in command]
+    if not scoped:
+        return []  # the documented line no longer carries the flag; nothing to re-scope
+    paths = untracked_files()
+    if not paths:
+        return []
+    return [command.replace(flag, _files_flag(paths)) for command in scoped]
 
 
 def run_gate(name: str, commands: list[str]) -> bool:
@@ -187,8 +267,14 @@ def run_gate(name: str, commands: list[str]) -> bool:
     """
     guarded = name in SKIP_GUARD
     env = GATE_ENV.get(name)
+    extra = _untracked_pass(name, commands)
+    if extra:
+        print(
+            f"\033[33mnote\033[0m: {name} is scoped by git, so untracked files get a second "
+            f"pass (#89). Add a genuinely disposable file to .gitignore to exclude it."
+        )
     try:
-        for command in commands:
+        for command in [*commands, *extra]:
             print(f"\n\033[1m→ {name}\033[0m: {command}", flush=True)
             status, stdout = _run(command, capture=guarded, env=env)
             if status != 0:

--- a/tests/test_gates_runner.py
+++ b/tests/test_gates_runner.py
@@ -11,14 +11,19 @@ that equality says nothing about:
   restructured-README case, which is the one that silently breaks both consumers;
 * the selection rule, because excluding ``lowest-deps`` by default is the difference
   between a runner and a footgun: it rewrites ``uv.lock`` in the working tree;
-* the #34 skip guard, which is the one place the runner deliberately does *more* than the
-  README line it runs. CI fails ``rhiza-test`` when any check skips, because a skipped
+* the #34 skip guard, the first of three places the runner deliberately does *more* than
+  the README line it runs. CI fails ``rhiza-test`` when any check skips, because a skipped
   assertion reads as a pass; a local run that reported green on the same output would be
   worse than no runner at all.
-* the environment in :data:`scripts.gates.GATE_ENV`, which is the other place it does more
-  than the README line — the value has to reach the child process, and the ambient
-  environment has to survive being added to (#81). Whether that value is the one ``ci.yml``
-  sets is ``tests/test_readme_gates.py``'s job, not this module's.
+* the environment in :data:`scripts.gates.GATE_ENV`, the second — the value has to reach the
+  child process, and the ambient environment has to survive being added to (#81). Whether
+  that value is the one ``ci.yml`` sets is ``tests/test_readme_gates.py``'s job, not this
+  module's.
+* the untracked second pass for the gates in :data:`scripts.gates.GIT_SCOPED`, the third
+  (#89). ``prek run --all-files`` means every file *git knows about*, so this gate alone
+  could pass a module CI would reject — and a brand-new module is exactly where a missing
+  lint exemption is most likely. The rewritten line is derived from the documented one, so
+  what is tested here is the rewrite and the paths, never a second copy of the command.
 
 The guard tests drive it with a trivial subprocess that prints the tell-tale word rather
 than with a real check run, because what is under test is the reading of the output, not
@@ -28,19 +33,26 @@ pytest.
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from scripts.gates import (
     DESTRUCTIVE,
     GATE_ENV,
+    GIT_SCOPED,
     GatesError,
     documented_gates,
     main,
     run_gate,
     select_gates,
+    untracked_files,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - import only for the fixture's type
+    from conftest import Subject
 
 # A fence with the two shapes that matter: a gate with one command, one with two, and a
 # destructive gate whose name is in DESTRUCTIVE.
@@ -407,3 +419,208 @@ class TestTheGateEnvironment:
         body = "import os; print('PATH=' + str('PATH' in os.environ))"
         assert run_gate("rhiza-test", [_script(body)]) is True
         assert "PATH=True" in capsys.readouterr().out
+
+
+def _argv_echo() -> str:
+    """Return a command line that prints the arguments it was given.
+
+    The untracked pass is a *rewrite* of a documented command line, so what has to be
+    asserted is the argv the child actually received — not that some second process ran.
+
+    Returns:
+        A command line for :func:`scripts.gates.run_gate`, ending in the whole-tree flag
+        that :data:`scripts.gates.GIT_SCOPED` names for `lint`.
+    """
+    body = "import sys; print('ARGV=' + ' '.join(sys.argv[1:]))"
+    return f"{_script(body)} {GIT_SCOPED['lint']}"
+
+
+def _argv_lines(out: str) -> list[str]:
+    """Return the lines the child processes printed, ignoring the runner's own echo.
+
+    :func:`scripts.gates.run_gate` prints each command line before running it, and the echo
+    of :func:`_argv_echo` contains the literal ``ARGV=`` inside its ``-c`` body — so a plain
+    substring count sees every command twice. Only the child's output *begins* a line with
+    it.
+
+    Args:
+        out: Captured stdout.
+
+    Returns:
+        One entry per child invocation, in order.
+    """
+    return [line for line in out.splitlines() if line.startswith("ARGV=")]
+
+
+@pytest.fixture
+def rooted(monkeypatch: pytest.MonkeyPatch, subject: Callable[..., Subject]) -> Callable[..., Subject]:
+    """Return a factory building a repository and repointing the runner's ``ROOT`` at it.
+
+    ``untracked_files`` asks git about :data:`scripts.gates.ROOT`, so a test needs a
+    repository it controls the untracked set of. Repointing is enough — nothing here runs a
+    documented command line, whose ``uvx`` invocations would need the real tree.
+
+    Args:
+        monkeypatch: Used to repoint the module-level ``ROOT``.
+        subject: The throwaway-repository factory from ``tests/conftest.py``.
+
+    Returns:
+        ``make(files=None, *, untracked=None) -> Subject``, where ``files`` are committed
+        and ``untracked`` are written afterwards and left uncommitted.
+    """
+
+    def make(files: dict[str, str] | None = None, *, untracked: dict[str, str] | None = None) -> Subject:
+        """Build the repository and repoint ``ROOT``.
+
+        Args:
+            files: Committed content.
+            untracked: Content written after the commit, so git neither tracks nor ignores
+                it unless a committed ``.gitignore`` says otherwise.
+
+        Returns:
+            The built subject.
+        """
+        repo = subject(files or {"seed.txt": "seed\n"})
+        if untracked:
+            repo.write(untracked)
+        monkeypatch.setattr("scripts.gates.ROOT", repo.path)
+        return repo
+
+    return make
+
+
+class TestUntrackedFiles:
+    """What the git-scoped gates cannot see, and what must stay invisible anyway."""
+
+    def test_a_file_git_neither_tracks_nor_ignores_is_listed(self, rooted: Callable[..., Subject]) -> None:
+        """The #89 case: a new module, written but not yet staged."""
+        rooted(untracked={"fresh.py": "x = 1\n"})
+
+        assert untracked_files() == ["fresh.py"]
+
+    def test_an_ignored_file_is_not_listed(self, rooted: Callable[..., Subject]) -> None:
+        """`--exclude-standard` is the escape hatch the note points contributors at.
+
+        A path in `.gitignore` is one the repository has deliberately disowned, so linting
+        it would convert the fix for a noisy scratch file into a lint failure.
+        """
+        rooted({".gitignore": "junk.txt\n"}, untracked={"junk.txt": "noise\n", "real.py": "x = 1\n"})
+
+        assert untracked_files() == ["real.py"]
+
+    def test_a_clean_tree_lists_nothing(self, rooted: Callable[..., Subject]) -> None:
+        """The normal state, and the one where this must cost no extra child process."""
+        rooted()
+
+        assert untracked_files() == []
+
+    def test_outside_a_repository_it_answers_empty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unknown is "nothing extra to lint", never an error.
+
+        This pass supplements the documented command; being unable to ask git must not be
+        able to fail a gate on its own.
+        """
+        monkeypatch.setattr("scripts.gates.ROOT", tmp_path)
+
+        assert untracked_files() == []
+
+
+class TestTheUntrackedPass:
+    """The second pass: when it happens, what it runs, and when it must not happen."""
+
+    def test_the_documented_command_runs_again_scoped_to_the_untracked_paths(
+        self, rooted: Callable[..., Subject], capfd: pytest.CaptureFixture[str]
+    ) -> None:
+        """The fix for #89: `--all-files` swapped for `--files <paths>`, same command.
+
+        Derived from the documented line rather than written out here, so the runner still
+        holds no recipes (#66) — asserted by the first pass and the second differing in
+        exactly that one flag.
+        """
+        rooted(untracked={"fresh.py": "x = 1\n"})
+
+        assert run_gate("lint", [_argv_echo()]) is True
+
+        out = capfd.readouterr().out
+        assert "ARGV=--all-files" in out, out
+        assert "ARGV=--files fresh.py" in out, out
+
+    def test_it_announces_itself_and_names_the_escape_hatch(
+        self, rooted: Callable[..., Subject], capfd: pytest.CaptureFixture[str]
+    ) -> None:
+        """A second pass nobody asked for has to say why it is happening."""
+        rooted(untracked={"fresh.py": "x = 1\n"})
+
+        run_gate("lint", [_argv_echo()])
+
+        out = capfd.readouterr().out
+        assert "#89" in out
+        assert ".gitignore" in out
+
+    def test_a_failure_in_the_second_pass_fails_the_gate(
+        self, rooted: Callable[..., Subject], capfd: pytest.CaptureFixture[str]
+    ) -> None:
+        """Otherwise the whole thing is decoration: the gate has to be able to go red.
+
+        The stub fails only when it is given `--files`, which is precisely the shape of the
+        defect — a command line that passes over the tracked tree and fails over the new
+        file.
+        """
+        body = "import sys; raise SystemExit('--files' in sys.argv)"
+        command = f"{_script(body)} {GIT_SCOPED['lint']}"
+        rooted(untracked={"fresh.py": "x = 1\n"})
+
+        assert run_gate("lint", [command]) is False
+
+    def test_a_clean_tree_runs_the_documented_command_once(
+        self, rooted: Callable[..., Subject], capfd: pytest.CaptureFixture[str]
+    ) -> None:
+        """No untracked files means no second pass, and no note either."""
+        rooted()
+
+        assert run_gate("lint", [_argv_echo()]) is True
+
+        out = capfd.readouterr().out
+        assert _argv_lines(out) == ["ARGV=--all-files"], out
+        assert "#89" not in out
+
+    def test_a_gate_that_is_not_git_scoped_gets_no_second_pass(
+        self, rooted: Callable[..., Subject], capfd: pytest.CaptureFixture[str]
+    ) -> None:
+        """`typecheck` walks the filesystem, so it already sees the untracked file.
+
+        Keyed by gate rather than applied to every gate carrying the flag: a second pass
+        over a gate that never needed one is wasted work, and `--all-files` means something
+        different to tools that are not prek.
+        """
+        rooted(untracked={"fresh.py": "x = 1\n"})
+
+        assert run_gate("typecheck", [_argv_echo()]) is True
+
+        out = capfd.readouterr().out
+        assert _argv_lines(out) == ["ARGV=--all-files"], out
+
+    def test_a_documented_line_without_the_flag_gets_no_second_pass(
+        self, rooted: Callable[..., Subject], capfd: pytest.CaptureFixture[str]
+    ) -> None:
+        """If the README stops scoping by git, this pass has nothing to re-scope.
+
+        Silently running the line unchanged a second time would be worse than not running
+        it: two identical passes read as coverage that is not there.
+        """
+        rooted(untracked={"fresh.py": "x = 1\n"})
+
+        assert run_gate("lint", [_script("import sys; print('ARGV=' + ' '.join(sys.argv[1:]))")]) is True
+
+        out = capfd.readouterr().out
+        assert _argv_lines(out) == ["ARGV="], out
+
+    def test_a_path_with_a_space_survives_the_round_trip(
+        self, rooted: Callable[..., Subject], capfd: pytest.CaptureFixture[str]
+    ) -> None:
+        """The rewritten line is re-split with `shlex.split`, so paths need quoting."""
+        rooted(untracked={"two words.py": "x = 1\n"})
+
+        assert run_gate("lint", [_argv_echo()]) is True
+
+        assert "ARGV=--files two words.py" in capfd.readouterr().out


### PR DESCRIPTION
Closes #89. One commit, on top of #88 (now merged) — filed separately so that PR stayed green and narrow.

## The defect

`python scripts/gates.py lint` returned **0** on a module CI would reject, for as long as that module was untracked.

`uvx prek run --all-files` means all files *git knows about*, not all files on disk. Verified with a deliberately untracked probe carrying a bare `assert` and no `ruff.toml` exemption:

```console
$ git status --porcelain src/pytest_rhiza/_scratch_probe.py
?? src/pytest_rhiza/_scratch_probe.py

$ python scripts/gates.py lint
ruff check...............................................................Passed
  PASS  lint                                   # exit 0

$ git add src/pytest_rhiza/_scratch_probe.py && uvx prek run --all-files
ruff check...............................................................Failed
  S101 Use of `assert` detected                # exit 1
```

Same file, same hooks, same config — only the git index differs.

**No other gate shares it.** With the same untracked probe present, `typecheck` reported `Success: no issues found in 20 source files` where it otherwise reports 18. mypy walks the filesystem; so do interrogate and the coverage run. That makes the inconsistency worse rather than better: a contributor who sees `typecheck` react to a new file reasonably assumes `lint` did too.

CI never reproduces it, because a fresh `actions/checkout` has everything tracked. So the gap could only ever appear as a red CI job on a green local run — the one thing `scripts/gates.py` exists to prevent.

**And it bites exactly where it matters most.** A brand-new module is the case where a missing `[lint.per-file-ignores]` entry is *most* likely, because the entry cannot exist yet. That is not hypothetical — it is how this was found. `_release_state.py` (added in #88) passed this gate while untracked and failed `ruff check` the moment it was staged.

## The fix

`GIT_SCOPED` names the gates whose documented command line is scoped by git, mapped to the flag doing the scoping. When such a gate runs and `git ls-files --others --exclude-standard` reports anything, the gate's **own documented command** runs a second time with that flag swapped for `--files <paths>`:

```
→ lint: uvx prek run --all-files --show-diff-on-failure
→ lint: uvx prek run --files src/pytest_rhiza/_scratch_probe.py --show-diff-on-failure
```

**Derived, not rewritten.** The second line is the first with one flag replaced, so the runner still holds no recipes (#66) and `--show-diff-on-failure` carries over for free. Writing a fresh `prek` invocation into `scripts/gates.py` would have been exactly the second home #52 removed — and it could then drift from the README the pin cannot see.

Three properties worth calling out:

- **`--exclude-standard` keeps it from being a nuisance.** A path in `.gitignore` is one the repository has deliberately disowned, so a genuinely disposable scratch file is excluded by the mechanism that already exists for it. The printed note says so rather than leaving the contributor to guess.
- **A clean tree costs one `git ls-files` and no extra child process.** Verified: with nothing untracked, the gate runs one command and prints no note.
- **Being unable to ask git is "nothing extra to lint", never an error.** This pass supplements the documented command; outside a repository, or with no git on `PATH`, it must not be able to fail a gate on its own.

## Tests

11 new tests in `tests/test_gates_runner.py`, driven through `run_gate` rather than the private helper, so what is asserted is the argv the child actually received:

- an untracked file is listed; an **ignored** one is not; a clean tree lists nothing; outside a repository the answer is empty
- the documented command runs again scoped to the untracked paths, and the two passes differ in exactly the one flag
- **a failure in the second pass fails the gate** — otherwise the whole thing is decoration
- no second pass for a gate outside `GIT_SCOPED`, for a documented line no longer carrying the flag, or for a clean tree
- a path containing a space survives the `shlex.split` round trip

The repositories come from the existing `subject` factory with `ROOT` repointed, so git is real and nothing is mocked.

## Gates

All nine non-destructive gates pass. **237 tests** (+11), coverage **100.00%**, `scripts/gates.py` at 129/129 statements. No block above CC 8 (`_untracked_pass` is 7, `run_gate` 7); average over `src` + `scripts` is A (3.02).

`README.md`, `CLAUDE.md` and the `tests/test_gates_runner.py` module docstring all enumerated the ways the runner deliberately does *more* than the README line it runs — "the one place", "the other place". There are now three (`SKIP_GUARD` #34, `GATE_ENV` #81, `GIT_SCOPED` #89); all three documents are updated rather than left to say two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
