### PR TITLE
fix: keep uv.lock's own version in step with the manifest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,12 @@ filename = "src/pytest_rhiza/__init__.py"
 search = "__version__ = \"{current_version}\""
 replace = "__version__ = \"{new_version}\""
 
+[[tool.bumpversion.files]]
+filename = "uv.lock"
+regex = true
+search = 'name = "pytest-rhiza"\nversion = "{current_version}"'
+replace = 'name = "pytest-rhiza"\nversion = "{new_version}"'
+
 # Source modules in src/pytest_rhiza/checks/ are deliberately named test_*.py because
 # they are pytest check modules collected out of site-packages via `--pyargs`. Mirroring
 # them with tests/pytest_rhiza/checks/test_test_*.py would produce nonsensical file names

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -17,18 +17,41 @@ The pattern is borrowed from the checks this package ships: ``checks/test_cargo_
 and ``checks/test_go_module.py`` both assert that their release config still targets the
 file the version actually lives in, and anchor the search rather than trusting a bare
 version string. Same invariant, applied to this repository's own manifest.
+
+**There is a third home, and it was missed the same way.** ``uv.lock`` records this
+project's own version in its ``pytest-rhiza`` package entry, and the v0.5.0 release
+commit left it reading ``0.4.1`` — so the tagged tree declared two different versions of
+itself. Every release up to v0.4.1 happened to be correct, which is what made it easy to
+miss: nothing *asserted* it, so the lock stayed in step only for as long as whoever cut
+the release happened to run a ``uv`` command between the bump and the commit. That is #12
+again, one file over: a version location kept correct by habit rather than by mechanism.
+The two tests below are duplicated for it, for the same reason there are two of them.
 """
 
 from __future__ import annotations
 
+import shutil
+import subprocess  # nosec B404
 import tomllib
 from pathlib import Path
 
+import pytest
+
 import pytest_rhiza
+
+_GIT = shutil.which("git") or "/usr/bin/git"
 
 # The location bump-my-version must rewrite alongside [project].version, spelled the way
 # a TOML `filename` key does — forward slashes on every platform.
 VERSION_MODULE = "src/pytest_rhiza/__init__.py"
+
+#: The lockfile also records this project's own version, in its own package entry. Same
+#: spelling rule as above: a TOML `filename` key, forward slashes on every platform.
+LOCKFILE = "uv.lock"
+
+#: The name uv records this project under in `uv.lock`, which is the distribution name
+#: rather than the import name — the underscore form would match nothing.
+DISTRIBUTION = "pytest-rhiza"
 
 PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
 
@@ -42,6 +65,53 @@ def _pyproject() -> dict:
     """
     with PYPROJECT.open("rb") as handle:
         return tomllib.load(handle)
+
+
+def _committed(path: str) -> str | None:
+    """Return the committed content of a repository-relative path.
+
+    **The working tree is the wrong thing to read here, and that is the whole point.**
+    ``uv run`` re-locks before it runs anything, so by the time pytest imports this module
+    the lockfile on disk has already been repaired to match the manifest — an assertion
+    over the file would pass no matter what was committed. That is precisely why the drift
+    went unnoticed: the ``test`` gate itself erases the evidence before reading it.
+
+    Args:
+        path: Repository-relative path, as git spells it.
+
+    Returns:
+        The file's content at ``HEAD``, or None when git cannot answer.
+    """
+    result = subprocess.run(
+        [_GIT, "show", f"HEAD:{path}"],
+        cwd=PYPROJECT.parent,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _locked_version(lock_text: str) -> str | None:
+    """Return the version a lockfile records for this project.
+
+    Parsed as TOML rather than matched with a regex: the lockfile *is* TOML, and its
+    ``[[package]]`` entries are what carry the version, so reading the structure says
+    exactly which package answered. A regex would have to re-derive that from adjacency.
+
+    Args:
+        lock_text: The lockfile's content.
+
+    Returns:
+        The version in this project's own package entry, or None when there is no entry
+        for it.
+    """
+    for package in tomllib.loads(lock_text).get("package", []):
+        if package.get("name") == DISTRIBUTION:
+            return str(package.get("version", ""))
+    return None
 
 
 def test_dunder_version_matches_pyproject() -> None:
@@ -80,4 +150,57 @@ def test_bumpversion_rewrites_the_dunder_version() -> None:
             f"the {VERSION_MODULE} entry's search {search!r} is not anchored to the "
             f"__version__ assignment; applied to every occurrence in the file, a bare "
             f"version would also rewrite one mentioned in the module docstring."
+        )
+
+
+def test_the_committed_uv_lock_matches_the_committed_pyproject() -> None:
+    """The committed tree must not declare two different versions of itself.
+
+    Both sides are read from ``HEAD`` rather than from disk, and they have to be: see
+    :func:`_committed` for why the working tree cannot answer this. Comparing committed
+    against committed also keeps the test honest mid-edit — a manifest bumped but not yet
+    committed is not drift, and reading one side from disk would report it as such.
+    """
+    lock_text = _committed(LOCKFILE)
+    manifest_text = _committed("pyproject.toml")
+    if lock_text is None or manifest_text is None:
+        pytest.skip("no committed tree to read — git could not answer")
+
+    locked = _locked_version(lock_text)
+    declared = tomllib.loads(manifest_text)["project"]["version"]
+
+    assert locked == declared, (
+        f"the committed {LOCKFILE} records {DISTRIBUTION} at {locked!r} while the committed "
+        f"[project].version is {declared!r}. A release rewrote the manifest and not the "
+        f"lockfile, so the tagged tree declares two versions of itself — which is exactly "
+        f"what v0.5.0 shipped."
+    )
+
+
+def test_bumpversion_rewrites_the_uv_lock_version() -> None:
+    """A ``[[tool.bumpversion.files]]`` entry must target the lockfile, anchored.
+
+    Anchoring matters more here than anywhere else in this repository. ``uv.lock`` holds a
+    ``version`` line for *every* resolved package, so a bare ``{current_version}`` search
+    would rewrite whichever one happened to sit at the same number — silently repinning a
+    dependency as a side effect of a release. The anchor is the distribution name on the
+    preceding line.
+    """
+    entries = [
+        entry
+        for entry in _pyproject().get("tool", {}).get("bumpversion", {}).get("files", [])
+        if entry.get("filename") == LOCKFILE
+    ]
+
+    assert entries, (
+        f"no [[tool.bumpversion.files]] entry targets {LOCKFILE}, so a bump would rewrite "
+        f"[project].version and leave the lockfile behind. That is not hypothetical: it is "
+        f"how the v0.5.0 tag came to carry a lockfile reading 0.4.1."
+    )
+    for entry in entries:
+        search = str(entry.get("search", ""))
+        assert DISTRIBUTION in search, (
+            f"the {LOCKFILE} entry's search {search!r} is not anchored to {DISTRIBUTION!r}. "
+            f"Every resolved package in the lockfile has a version line, so an unanchored "
+            f"search can repin a dependency that happens to share this project's number."
         )

--- a/uv.lock
+++ b/uv.lock
@@ -198,7 +198,7 @@ wheels = [
 
 [[package]]
 name = "pytest-rhiza"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
Found while running `/rhiza:release` for v0.5.0 — the release succeeded, but it left the repository inconsistent.

## The defect

`uv.lock` records this project's **own** version in its `pytest-rhiza` package entry. The v0.5.0 release commit (`1cc8cd0`) rewrote `pyproject.toml` and `src/pytest_rhiza/__init__.py` and left the lockfile at `0.4.1`, so the `v0.5.0` tag carries a tree declaring two different versions of itself:

```console
$ git show v0.5.0:pyproject.toml | grep -m1 '^version'
version = "0.5.0"
$ git show v0.5.0:uv.lock | grep -A1 '^name = "pytest-rhiza"$'
name = "pytest-rhiza"
version = "0.4.1"
```

**The published artifact is fine** — wheels build from the manifest, and PyPI serves 0.5.0 correctly. What is wrong is the repository.

## Why it was easy to miss

Every release up to v0.4.1 was correct:

| tag | pyproject | uv.lock | |
|---|---|---|---|
| v0.2.2 | 0.2.2 | 0.2.2 | OK |
| v0.3.0 | 0.3.0 | 0.3.0 | OK |
| v0.4.0 | 0.4.0 | 0.4.0 | OK |
| v0.4.1 | 0.4.1 | 0.4.1 | OK |
| v0.5.0 | 0.5.0 | **0.4.1** | **DRIFT** |

`d7909d2` and `e25f490` both carry `uv.lock | 2 +-`. Nothing in the config put it there: the lock stayed in step only because whoever cut those releases happened to run a `uv` command between the bump and the commit, so `git add --all` swept the result in. Habit, not mechanism — #12 one file over.

## Why the `test` gate could never have caught it

This is the part worth reading. **`uv run` re-locks before running anything**, so the gate repairs the evidence before pytest reads it:

```console
$ git checkout uv.lock                       # restore the committed, stale lock
$ git show HEAD:uv.lock | grep -A1 pytest-rhiza
version = "0.4.1"
$ uv run --group test python -c "pass"
$ grep -A1 '^name = "pytest-rhiza"$' uv.lock
version = "0.5.0"                            # repaired, before any test ran
```

A first draft of the drift test read the working tree and reported `4 passed` against the stale committed lock. So the assertion reads **both sides from `HEAD`** instead. Comparing committed against committed also avoids a false failure mid-edit, when a manifest is bumped but not yet committed.

## The fix

1. **`uv.lock` → 0.5.0.**
2. **A `[[tool.bumpversion.files]]` entry targets it**, so the bump maintains it as it already maintains `__version__`. Anchored to the distribution name on the preceding line — the lockfile carries a `version` line for *every* resolved package, so an unanchored `{current_version}` search would silently repin whichever dependency happened to share this project's number. Verified against the real file: `Found 'name = "pytest-rhiza"\nversion = "0.5.0"' at line 200`.
3. **Two tests**, mirroring the pair that guards `__version__`: one catches the drift, one catches the *cause* by asserting the entry still exists and is still anchored. Deleting the entry produces no drift until the next bump, which is the #12 lesson.

Both were verified non-vacuous — the drift test fails on the committed defect before the lock is corrected:

```
AssertionError: the committed uv.lock records pytest-rhiza at '0.4.1' while the
committed [project].version is '0.5.0'. ... which is exactly what v0.5.0 shipped.
```

A dry run confirms a future bump now moves all three homes:

```
Would change file src/pytest_rhiza/__init__.py
Would change file uv.lock
Would change file pyproject.toml
```

## Not fixed here, deliberately

**The `v0.5.0` tag keeps its stale lock.** A published tag is immutable and moving it is disruptive to anyone who has fetched it; the drift is cosmetic in the tag and corrected from `main` forward.

## Gates

All nine non-destructive gates pass. **239 tests** (+2), coverage **100.00%**. `git status` now stays clean after a `uv run`, which it did not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
