### PR TITLE
fix: drop the non-existent --no-locked flag from the weekly job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
   # The major-version ignore is kept *here* and dropped from github-actions below (#75),
   # because the two ecosystems fail differently. The runtime constraints in pyproject.toml
   # are deliberately loose floors (`pytest>=8.1`), so a new major needs no manifest edit to
-  # be picked up, and `weekly.yml`'s `dep-compat` job resolves with `--upgrade --no-locked`
+  # be picked up, and `weekly.yml`'s `dep-compat` job resolves with `--upgrade`
   # every Monday specifically to catch one that breaks this package. Actions have neither
   # property: a SHA pin is exact, and nothing else re-resolves it.
   - package-ecosystem: "uv"

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -41,9 +41,14 @@ jobs:
       # rhiza-managed repo's test environment, so a break here is a break everywhere.
       #
       # `--upgrade` rather than `--frozen`: resolving fresh is the entire point, so this job
-      # deliberately does not use uv.lock.
+      # deliberately does not use uv.lock. `--upgrade` is the whole instruction — it
+      # re-resolves every dependency to the newest compatible version and rewrites the lock
+      # in the runner's checkout, which is thrown away. There is no companion flag to add:
+      # `--no-locked` does not exist (uv has `--locked`, `--frozen`, `--no-sync`), and it
+      # failed the job with `unexpected argument '--no-locked' found` rather than silently
+      # resolving from the lockfile.
       - name: Resolve fresh and run the suite
-        run: uv run --group test --upgrade --no-locked pytest -ra
+        run: uv run --group test --upgrade pytest -ra
 
   link-check:
     name: Check links in README.md


### PR DESCRIPTION
## What

`weekly.yml`'s `dep-compat` job ran

```
uv run --group test --upgrade --no-locked pytest -ra
```

`--no-locked` is not a uv flag. uv has `--locked`, `--frozen` and `--no-sync`, so the step died in argument parsing before pytest was ever reached:

```
error: unexpected argument '--no-locked' found
  tip: a similar argument exists: '--locked'
Error: Process completed with exit code 2.
```

## Why it matters

The job has therefore produced **no signal since it was written**. Its whole purpose is to catch a newly-released `pytest` or `packaging` that breaks this package before it reaches every rhiza-managed repo's test environment — and it was red on arrival, the same shape as the `gitlab-docker` stub #52 removed.

## The fix

`--upgrade` alone is the whole instruction: it re-resolves every dependency to the newest compatible version and rewrites `uv.lock` in the runner's checkout, which is thrown away. There is no companion flag to add. The comment above the step now says that and names the failure, so the flag does not creep back.

The stale `--upgrade --no-locked` mention in `.github/dependabot.yml`'s rationale for the major-version ignore is updated to match.

## Verification

- `uv run --group test --upgrade pytest -ra` locally: resolves fresh (rewrites `uv.lock`, restored afterwards) and passes 239 tests.
- Full suite green; both YAML files parse; `actionlint` passes via the pre-commit hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)