### PR TITLE
docs: add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # pytest-rhiza
 
+[![PyPI version](https://badge.fury.io/py/pytest-rhiza.svg)](https://pypi.org/project/pytest-rhiza/)
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![Python versions](https://img.shields.io/badge/Python-3.11%20%E2%80%A2%203.12%20%E2%80%A2%203.13%20%E2%80%A2%203.14-blue?logo=python)](https://www.python.org/)
+[![CI](https://github.com/jebel-quant/pytest-rhiza/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/jebel-quant/pytest-rhiza/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/jebel-quant/pytest-rhiza/actions/workflows/codeql.yml/badge.svg?event=push)](https://github.com/jebel-quant/pytest-rhiza/actions/workflows/codeql.yml)
+[![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg?logo=ruff)](https://github.com/astral-sh/ruff)
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Jebel-Quant/pytest-rhiza/badge)](https://scorecard.dev/viewer/?uri=github.com/Jebel-Quant/pytest-rhiza)
+[![Downloads](https://static.pepy.tech/personalized-badge/pytest-rhiza?period=month&units=international_system&left_color=black&right_color=orange&left_text=PyPI%20downloads%20per%20month)](https://pepy.tech/project/pytest-rhiza)
+
 The [rhiza](https://github.com/jebel-quant/rhiza) repository checks, installed as a pytest
 plugin instead of synced into every consumer repository as `.rhiza/tests/`.
 


### PR DESCRIPTION
Adds a badge block under the README title, modelled on
[jebel-quant/jquantstats](https://github.com/jebel-quant/jquantstats), with the set
trimmed to badges this repository can actually back.

| badge | source |
| --- | --- |
| PyPI version | badge.fury → the published package |
| License: MIT | `LICENSE` |
| Python versions | 3.11 • 3.12 • 3.13 • 3.14, matching the classifiers and the CI matrix |
| CI | `ci.yml`, `?event=push` |
| CodeQL | `codeql.yml`, `?event=push` |
| Code style: ruff | `ruff.toml` is the single source of truth for rules and formatting |
| uv | the resolver this repo is built and locked with |
| OpenSSF Scorecard | `scorecard.yml` publishes with `publish_results: true` — currently 6.9 |
| Downloads | pepy, per month |

## What was dropped from the jquantstats set, and why

- **CodeFactor** — `codefactor.io/repository/github/jebel-quant/pytest-rhiza/badge` returns
  404; the repo is not imported there, so the badge would render dead.
- **Coverage and docs** — jquantstats serves both from its GitHub Pages site. There is no
  `gh-pages` branch and no `mkdocs.yml` here, so there is nothing to point at.
- **Rhiza template badge** — it reads `.rhiza/template.yml`, and this repo deliberately has
  no `.rhiza/`: CLAUDE.md's "Nothing here invokes `jebel-quant/rhiza`" is the reason, since
  rhiza pins this package as a dependency.

## One thing worth knowing

The Scorecard badge spells the owner **`Jebel-Quant`**, not lowercase. `api.scorecard.dev`
is case-sensitive on the owner: lowercase returns `openssf scorecard: invalid repo path`.
That means jquantstats' own Scorecard badge is broken today for exactly this reason — its
URL uses `jebel-quant`. Worth a separate fix over there.

## Checks

Every badge URL was fetched before committing, not copied and hoped for: `CI - passing`,
`CodeQL - passing`, `openssf scorecard: 6.9`, and real SVG bodies from shields, pepy and
badge.fury.

- `uvx prek run --all-files` passes — markdownlint included, since MD013 (line length) is
  off in `.markdownlint.yaml`, so the long badge lines are fine.
- `uv run pytest` — 239 passed.
- No version literal enters the file, so `tests/test_readme_pin.py` stays green; the change
  touches no fence, so `tests/test_readme_gates.py` and `scripts/gates.py` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
